### PR TITLE
Support new version Devices.(RTL_VER_13)

### DIFF
--- a/50-usb-realtek-net.rules
+++ b/50-usb-realtek-net.rules
@@ -9,6 +9,7 @@ ENV{REALTEK_NIC_MODE}="1"
 
 # Realtek
 ATTR{idVendor}=="0bda", ATTR{idProduct}=="8156", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+ATTR{idVendor}=="0bda", ATTR{idProduct}=="8155", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
 ATTR{idVendor}=="0bda", ATTR{idProduct}=="8153", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
 ATTR{idVendor}=="0bda", ATTR{idProduct}=="8152", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
 
@@ -34,5 +35,8 @@ ATTR{idVendor}=="2357", ATTR{idProduct}=="0601", ATTR{bConfigurationValue}!="$en
 
 # Nvidia
 ATTR{idVendor}=="0955", ATTR{idProduct}=="09ff", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
+
+# LINKSYS
+ATTR{idVendor}=="13b1", ATTR{idProduct}=="0041", ATTR{bConfigurationValue}!="$env{REALTEK_NIC_MODE}", ATTR{bConfigurationValue}="$env{REALTEK_NIC_MODE}"
 
 LABEL="usb_realtek_net_end"

--- a/INFO.sh
+++ b/INFO.sh
@@ -4,7 +4,7 @@
 source /pkgscripts-ng/include/pkg_util.sh
 
 package="r8152"
-version="2.12.0-3"
+version="2.13.0-1"
 displayname="RTL8152/RTL8153 driver"
 maintainer="bb-qq"
 arch="$(pkg_get_platform)"

--- a/Makefile
+++ b/Makefile
@@ -2,25 +2,48 @@
 #
 #
 
-TARGET := r8152.ko
 CONFIG_CTAP_SHORT = ON
 
-obj-m	 := r8152.o
+ifneq ($(KERNELRELEASE),)
+	obj-m	 := r8152.o
 #	EXTRA_CFLAGS += -DRTL8152_S5_WOL
 #	EXTRA_CFLAGS += -DRTL8152_DEBUG
-ifneq (,$(filter OFF off, $(CONFIG_CTAP_SHORT)))
-	EXTRA_CFLAGS += -DCONFIG_CTAP_SHORT_OFF
-endif
+	ifneq (,$(filter OFF off, $(CONFIG_CTAP_SHORT)))
+		EXTRA_CFLAGS += -DCONFIG_CTAP_SHORT_OFF
+	endif
+else
+	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+	PWD :=$(shell pwd)
+	TARGET_PATH := kernel/drivers/net/usb
+	INBOXDRIVER := $(shell find $(subst build,$(TARGET_PATH),$(KERNELDIR)) -name r8152.ko.* -type f)
+	RULEFILE = 50-usb-realtek-net.rules
+	RULEDIR = /etc/udev/rules.d/
 
 .PHONY: modules
-$(TARGET):
-	$(MAKE) -C $(KSRC) M=$(PWD) modules
+modules:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+
+.PHONY: all
+all: clean modules install
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
 
 .PHONY: install
-install: $(TARGET)
-	mkdir -p $(DESTDIR)/r8152/
-	install $< $(DESTDIR)/r8152/
+install:
+ifneq ($(shell lsmod | grep r8152),)
+	rmmod r8152
+endif
+ifneq ($(INBOXDRIVER),)
+	rm -f $(INBOXDRIVER)
+endif
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) INSTALL_MOD_DIR=$(TARGET_PATH) modules_install
+	modprobe r8152
+
+.PHONY: install_rules
+install_rules:
+	install --group=root --owner=root --mode=0644 $(RULEFILE) $(RULEDIR)
+
+endif
+

--- a/Makefile
+++ b/Makefile
@@ -2,48 +2,25 @@
 #
 #
 
+TARGET := r8152.ko
 CONFIG_CTAP_SHORT = ON
 
-ifneq ($(KERNELRELEASE),)
-	obj-m	 := r8152.o
+obj-m	 := r8152.o
 #	EXTRA_CFLAGS += -DRTL8152_S5_WOL
 #	EXTRA_CFLAGS += -DRTL8152_DEBUG
-	ifneq (,$(filter OFF off, $(CONFIG_CTAP_SHORT)))
-		EXTRA_CFLAGS += -DCONFIG_CTAP_SHORT_OFF
-	endif
-else
-	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
-	PWD :=$(shell pwd)
-	TARGET_PATH := kernel/drivers/net/usb
-	INBOXDRIVER := $(shell find $(subst build,$(TARGET_PATH),$(KERNELDIR)) -name r8152.ko.* -type f)
-	RULEFILE = 50-usb-realtek-net.rules
-	RULEDIR = /etc/udev/rules.d/
+ifneq (,$(filter OFF off, $(CONFIG_CTAP_SHORT)))
+	EXTRA_CFLAGS += -DCONFIG_CTAP_SHORT_OFF
+endif
 
 .PHONY: modules
-modules:
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
-
-.PHONY: all
-all: clean modules install
+$(TARGET):
+	$(MAKE) -C $(KSRC) M=$(PWD) modules
 
 .PHONY: clean
 clean:
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
+	rm -rf *.o $(TARGET)
 
 .PHONY: install
-install:
-ifneq ($(shell lsmod | grep r8152),)
-	rmmod r8152
-endif
-ifneq ($(INBOXDRIVER),)
-	rm -f $(INBOXDRIVER)
-endif
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) INSTALL_MOD_DIR=$(TARGET_PATH) modules_install
-	modprobe r8152
-
-.PHONY: install_rules
-install_rules:
-	install --group=root --owner=root --mode=0644 $(RULEFILE) $(RULEDIR)
-
-endif
-
+install: $(TARGET)
+	mkdir -p $(DESTDIR)/r8152/
+	install $< $(DESTDIR)/r8152/

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -18,7 +18,12 @@
 
 - Example of setting speed
 
-	# ethtool -s eth0 autoneg on advertise 0x802f (2.5G)
+	2.5G before kernel v4.10
+	# ethtool -s eth0 autoneg on advertise 0x802f
+
+	2.5G for kernel v4.10 and later
+	# ethtool -s eth0 autoneg on advertise 0x80000000002f
+
 	# ethtool -s eth0 autoneg on advertise 0x002f (1G)
 	# ethtool -s eth0 autoneg on advertise 0x000f (100M full)
 	# ethtool -s eth0 autoneg on advertise 0x0003 (10M full)
@@ -26,3 +31,11 @@
 - Disable center tap short
 
 	# make CONFIG_CTAP_SHORT=OFF modules
+
+- Ring parameter
+
+	Show Ring parameter
+	# ethtool -g eth0
+
+	Changes the number of ring entries for the Rx ring.
+	# ethtool -G eth0 rx 100

--- a/compatibility.h
+++ b/compatibility.h
@@ -16,9 +16,15 @@
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0) */
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31) */
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
 	#define SPEED_2500				2500
 	#define SPEED_25000				25000
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+	#ifndef ETHTOOL_LINK_MODE_2500baseT_Full_BIT
+	#define ETHTOOL_LINK_MODE_2500baseT_Full_BIT	ETHTOOL_LINK_MODE_2500baseX_Full_BIT
+	#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0)
 	#define BMCR_SPEED10				0x0000
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,5,0)
@@ -43,6 +49,7 @@
 	#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0)
 	#define IS_ERR_OR_NULL(ptr)			(!ptr)
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,14,0)
 	#define ether_addr_copy(dst, src)		memcpy(dst, src, ETH_ALEN)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
@@ -50,6 +57,7 @@
 	#define BIT_ULL(nr)				(1ULL << (nr))
 	#define BITS_PER_BYTE				8
 	#define reinit_completion(x)			((x)->done = 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,12,0)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
 	#define NETIF_F_HW_VLAN_CTAG_RX			NETIF_F_HW_VLAN_RX
 	#define NETIF_F_HW_VLAN_CTAG_TX			NETIF_F_HW_VLAN_TX
@@ -57,13 +65,6 @@
 	#define USB_DEVICE_INTERFACE_CLASS(vend, prod, iclass) \
 		USB_DEVICE_AND_INTERFACE_INFO(vend, prod, iclass, 0xff, 0)
 
-	static inline __sum16 tcp_v6_check(int len,
-					   const struct in6_addr *saddr,
-					   const struct in6_addr *daddr,
-					   __wsum base)
-	{
-		return csum_ipv6_magic(saddr, daddr, len, IPPROTO_TCP, base);
-	}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
 	#ifndef SPEED_UNKNOWN
 		#define SPEED_UNKNOWN		0
@@ -80,10 +81,6 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
 	#define ETH_MDIO_SUPPORTS_C22			MDIO_SUPPORTS_C22
 
-	static inline void eth_hw_addr_random(struct net_device *dev)
-	{
-		random_ether_addr(dev->dev_addr);
-	}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0)
 	#define module_usb_driver(__driver) \
 	static int __init __driver##_init(void) \
@@ -101,20 +98,6 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,2,0)
 	#define PMSG_IS_AUTO(msg)	(((msg).event & PM_EVENT_AUTO) != 0)
 
-	static inline struct page *skb_frag_page(const skb_frag_t *frag)
-	{
-		return frag->page;
-	}
-
-	static inline void *skb_frag_address(const skb_frag_t *frag)
-	{
-		return page_address(skb_frag_page(frag)) + frag->page_offset;
-	}
-
-	static inline unsigned int skb_frag_size(const skb_frag_t *frag)
-	{
-		return frag->size;
-	}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,1,0)
 	#define ndo_set_rx_mode				ndo_set_multicast_list
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,39)
@@ -126,45 +109,13 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37)
 	#define skb_checksum_none_assert(skb_ptr)	(skb_ptr)->ip_summed = CHECKSUM_NONE
 
-	static inline __be16 vlan_get_protocol(const struct sk_buff *skb)
-	{
-	       __be16 protocol = 0;
-
-	       if (vlan_tx_tag_present(skb) ||
-	            skb->protocol != cpu_to_be16(ETH_P_8021Q))
-	               protocol = skb->protocol;
-	       else {
-	               __be16 proto, *protop;
-	               protop = skb_header_pointer(skb, offsetof(struct vlan_ethhdr,
-	                                               h_vlan_encapsulated_proto),
-	                                               sizeof(proto), &proto);
-	               if (likely(protop))
-	                       protocol = *protop;
-	       }
-
-	       return protocol;
-	}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36)
 	#define skb_tx_timestamp(skb)
 
 	#define queue_delayed_work(long_wq, work, delay)	schedule_delayed_work(work, delay)
 
-	static inline void usleep_range(unsigned long min, unsigned long max)
-	{
-		unsigned long ms = min / 1000;
-
-		if (ms)
-			mdelay(ms);
-
-		udelay(min % 1000);
-	}
-
 	#define work_busy(x)				0
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35)
-	static inline bool pci_dev_run_wake(struct pci_dev *dev)
-	{
-		return 1;
-	}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,34)
 	#define netdev_mc_count(netdev)			((netdev)->mc_count)
 	#define netdev_mc_empty(netdev)			(netdev_mc_count(netdev) == 0)
@@ -190,23 +141,9 @@
 	#define netif_info(priv, type, netdev, fmt, args...)		\
 		netif_printk(priv, type, KERN_INFO, (netdev), fmt, ##args)
 
-	static inline int usb_enable_autosuspend(struct usb_device *udev)
-	{ return 0; }
-	static inline int usb_disable_autosuspend(struct usb_device *udev)
-	{ return 0; }
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
 	#define get_sset_count				get_stats_count
 
-	static inline
-	struct sk_buff *netdev_alloc_skb_ip_align(struct net_device *dev,
-						  unsigned int length)
-	{
-		struct sk_buff *skb = netdev_alloc_skb(dev, length + NET_IP_ALIGN);
-
-		if (NET_IP_ALIGN && skb)
-			skb_reserve(skb, NET_IP_ALIGN);
-		return skb;
-	}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32)
 	#define pm_request_resume(para)
 	#define pm_runtime_set_suspended(para)
@@ -227,43 +164,140 @@
 	#define vlan_gro_receive(napi, grp, vlan_tci, skb) \
 		vlan_hwaccel_receive_skb(skb, grp, vlan_tci)
 
-	static inline void usb_autopm_put_interface_async(struct usb_interface *intf)
-	{
-		struct usb_device *udev = interface_to_usbdev(intf);
-		int status = 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,27)
+	#define PM_EVENT_AUTO		0x0400
 
-		if (intf->condition == USB_INTERFACE_UNBOUND) {
-			status = -ENODEV;
-		} else {
-			udev->last_busy = jiffies;
-			--intf->pm_usage_cnt;
-			if (udev->autosuspend_disabled || udev->autosuspend_delay < 0)
-				status = -EPERM;
-		}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24)
+	struct napi_struct {
+		struct list_head	poll_list;
+		unsigned long		state;
+		int			weight;
+		int			(*poll)(struct napi_struct *, int);
+	#ifdef CONFIG_NETPOLL
+		spinlock_t		poll_lock;
+		int			poll_owner;
+		struct net_device	*dev;
+		struct list_head	dev_list;
+	#endif
+	};
+
+	#define napi_enable(napi_ptr)			netif_poll_enable(container_of(napi_ptr, struct r8152, napi)->netdev)
+	#define napi_disable(napi_ptr)			netif_poll_disable(container_of(napi_ptr, struct r8152, napi)->netdev)
+	#define napi_schedule(napi_ptr)			netif_rx_schedule(container_of(napi_ptr, struct r8152, napi)->netdev)
+	#define napi_complete(napi_ptr)			netif_rx_complete(container_of(napi_ptr, struct r8152, napi)->netdev)
+	#define netif_napi_add(ndev, napi_ptr, function, weight_t) \
+		ndev->poll = function; \
+		ndev->weight = weight_t;
+	typedef unsigned long				uintptr_t;
+	#define DMA_BIT_MASK(value) \
+		(value < 64 ? ((1ULL << value) - 1) : 0xFFFFFFFFFFFFFFFFULL)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,23)
+	#define NETIF_F_IPV6_CSUM			16
+	#define cancel_delayed_work_sync		cancel_delayed_work
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)
+	#define ip_hdr(skb_ptr)				(skb_ptr)->nh.iph
+	#define ipv6hdr(skb_ptr)			(skb_ptr)->nh.ipv6h
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,21)
+	#define vlan_group_set_device(vlgrp, vid, value) \
+		if (vlgrp) \
+			(vlgrp)->vlan_devices[vid] = value;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
+	#define delayed_work				work_struct
+	#define INIT_DELAYED_WORK(a,b)			INIT_WORK(a,b,tp)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,19)
+	#define CHECKSUM_PARTIAL			CHECKSUM_HW
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,18)
+	#define skb_is_gso(skb_ptr)			skb_shinfo(skb_ptr)->tso_size
+	#define netdev_alloc_skb(dev, len)		dev_alloc_skb(len)
+	#define IRQF_SHARED				SA_SHIRQ
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,16)
+	#ifndef __LINUX_MUTEX_H
+	#define mutex					semaphore
+	#define mutex_lock				down
+	#define mutex_unlock				up
+	#define mutex_trylock				down_trylock
+	#define mutex_lock_interruptible		down_interruptible
+	#define mutex_init				init_MUTEX
+	#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,14)
+	#define ADVERTISED_Pause			(1 << 13)
+	#define ADVERTISED_Asym_Pause			(1 << 14)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,12)
+	#define skb_header_cloned(skb)			skb_cloned(skb)
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,12) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,14) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,16) */
+	static inline struct sk_buff *skb_gso_segment(struct sk_buff *skb, int features)
+	{
+		return NULL;
 	}
-
-	static inline int usb_autopm_get_interface_async(struct usb_interface *intf)
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,18) */
+	static inline void *kmemdup(const void *src, size_t len, gfp_t gfp)
 	{
-		struct usb_device *udev = interface_to_usbdev(intf);
-		int status = 0;
+		void *p;
 
-		if (intf->condition == USB_INTERFACE_UNBOUND)
-			status = -ENODEV;
-		else if (udev->autoresume_disabled)
-			status = -EPERM;
-		else
-			++intf->pm_usage_cnt;
-		return status;
+		p = kmalloc_track_caller(len, gfp);
+		if (p)
+			memcpy(p, src, len);
+		return p;
 	}
-
-	static inline int eth_change_mtu(struct net_device *dev, int new_mtu)
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,19) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,21) */
+	static inline void skb_copy_from_linear_data(const struct sk_buff *skb,
+						     void *to,
+						     const unsigned int len)
 	{
-		if (new_mtu < 68 || new_mtu > ETH_DATA_LEN)
-			return -EINVAL;
-		dev->mtu = new_mtu;
+		memcpy(to, skb->data, len);
+	}
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22) */
+	static inline int skb_cow_head(struct sk_buff *skb, unsigned int headroom)
+	{
+		int delta = 0;
+
+		if (headroom > skb_headroom(skb))
+			delta = headroom - skb_headroom(skb);
+
+		if (delta || skb_header_cloned(skb))
+			return pskb_expand_head(skb, ALIGN(delta, NET_SKB_PAD),
+						0, GFP_ATOMIC);
 		return 0;
 	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28)
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,23) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24) */
+	static inline void __list_splice2(const struct list_head *list,
+					  struct list_head *prev,
+					  struct list_head *next)
+	{
+		struct list_head *first = list->next;
+		struct list_head *last = list->prev;
+
+		first->prev = prev;
+		prev->next = first;
+
+		last->next = next;
+		next->prev = last;
+	}
+
+	static inline void list_splice_tail(struct list_head *list,
+					    struct list_head *head)
+	{
+		if (!list_empty(list))
+			__list_splice2(list, head->prev, head);
+	}
+
+	static inline void netif_napi_del(struct napi_struct *napi)
+	{
+	#ifdef CONFIG_NETPOLL
+	        list_del(&napi->dev_list);
+	#endif
+	}
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,27) */
 	static inline void __skb_queue_splice(const struct sk_buff_head *list,
 					      struct sk_buff *prev,
 					      struct sk_buff *next)
@@ -302,159 +336,152 @@
 			__skb_queue_head_init(list);
 		}
 	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,27)
-	#define PM_EVENT_AUTO		0x0400
-
-	static inline void __list_splice2(const struct list_head *list,
-					  struct list_head *prev,
-					  struct list_head *next)
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28) */
+	static inline void usb_autopm_put_interface_async(struct usb_interface *intf)
 	{
-		struct list_head *first = list->next;
-		struct list_head *last = list->prev;
+		struct usb_device *udev = interface_to_usbdev(intf);
+		int status = 0;
 
-		first->prev = prev;
-		prev->next = first;
-
-		last->next = next;
-		next->prev = last;
+		if (intf->condition == USB_INTERFACE_UNBOUND) {
+			status = -ENODEV;
+		} else {
+			udev->last_busy = jiffies;
+			--intf->pm_usage_cnt;
+			if (udev->autosuspend_disabled || udev->autosuspend_delay < 0)
+				status = -EPERM;
+		}
 	}
 
-	static inline void list_splice_tail(struct list_head *list,
-					    struct list_head *head)
+	static inline int usb_autopm_get_interface_async(struct usb_interface *intf)
 	{
-		if (!list_empty(list))
-			__list_splice2(list, head->prev, head);
+		struct usb_device *udev = interface_to_usbdev(intf);
+		int status = 0;
+
+		if (intf->condition == USB_INTERFACE_UNBOUND)
+			status = -ENODEV;
+		else if (udev->autoresume_disabled)
+			status = -EPERM;
+		else
+			++intf->pm_usage_cnt;
+		return status;
 	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24)
-	struct napi_struct {
-		struct list_head	poll_list;
-		unsigned long		state;
-		int			weight;
-		int			(*poll)(struct napi_struct *, int);
-	#ifdef CONFIG_NETPOLL
-		spinlock_t		poll_lock;
-		int			poll_owner;
-		struct net_device	*dev;
-		struct list_head	dev_list;
-	#endif
-	};
 
-	#define napi_enable(napi_ptr)			netif_poll_enable(container_of(napi_ptr, struct r8152, napi)->netdev)
-	#define napi_disable(napi_ptr)			netif_poll_disable(container_of(napi_ptr, struct r8152, napi)->netdev)
-	#define napi_schedule(napi_ptr)			netif_rx_schedule(container_of(napi_ptr, struct r8152, napi)->netdev)
-	#define napi_complete(napi_ptr)			netif_rx_complete(container_of(napi_ptr, struct r8152, napi)->netdev)
-	#define netif_napi_add(ndev, napi_ptr, function, weight_t) \
-		ndev->poll = function; \
-		ndev->weight = weight_t;
-	typedef unsigned long				uintptr_t;
-	#define DMA_BIT_MASK(value) \
-		(value < 64 ? ((1ULL << value) - 1) : 0xFFFFFFFFFFFFFFFFULL)
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,23)
-	#define NETIF_F_IPV6_CSUM			16
-	#define cancel_delayed_work_sync		cancel_delayed_work
-
-	static inline int skb_cow_head(struct sk_buff *skb, unsigned int headroom)
+	static inline int eth_change_mtu(struct net_device *dev, int new_mtu)
 	{
-		int delta = 0;
-
-		if (headroom > skb_headroom(skb))
-			delta = headroom - skb_headroom(skb);
-
-		if (delta || skb_header_cloned(skb))
-			return pskb_expand_head(skb, ALIGN(delta, NET_SKB_PAD),
-						0, GFP_ATOMIC);
+		if (new_mtu < 68 || new_mtu > ETH_DATA_LEN)
+			return -EINVAL;
+		dev->mtu = new_mtu;
 		return 0;
 	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)
-	#define ip_hdr(skb_ptr)				(skb_ptr)->nh.iph
-	#define ipv6hdr(skb_ptr)			(skb_ptr)->nh.ipv6h
-
-	static inline void skb_copy_from_linear_data(const struct sk_buff *skb,
-						     void *to,
-						     const unsigned int len)
-	{
-		memcpy(to, skb->data, len);
-	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,21)
-	#define vlan_group_set_device(vlgrp, vid, value) \
-		if (vlgrp) \
-			(vlgrp)->vlan_devices[vid] = value;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
-	#define delayed_work				work_struct
-	#define INIT_DELAYED_WORK(a,b)			INIT_WORK(a,b,tp)
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,19)
-	#define CHECKSUM_PARTIAL			CHECKSUM_HW
-
-	static inline void *kmemdup(const void *src, size_t len, gfp_t gfp)
-	{
-		void *p;
-
-		p = kmalloc_track_caller(len, gfp);
-		if (p)
-			memcpy(p, src, len);
-		return p;
-	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,18)
-	#define skb_is_gso(skb_ptr)			skb_shinfo(skb_ptr)->tso_size
-	#define netdev_alloc_skb(dev, len)		dev_alloc_skb(len)
-	#define IRQF_SHARED				SA_SHIRQ
-
-	static inline struct sk_buff *skb_gso_segment(struct sk_buff *skb, int features)
-	{
-		return NULL;
-	}
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,16)
-	#ifndef __LINUX_MUTEX_H
-	#define mutex					semaphore
-	#define mutex_lock				down
-	#define mutex_unlock				up
-	#define mutex_trylock				down_trylock
-	#define mutex_lock_interruptible		down_interruptible
-	#define mutex_init				init_MUTEX
-	#endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,14)
-	#define ADVERTISED_Pause			(1 << 13)
-	#define ADVERTISED_Asym_Pause			(1 << 14)
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,12)
-	#define skb_header_cloned(skb)			skb_cloned(skb)
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,12) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,14) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,16) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,18) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,19) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,21) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,23) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24) */
-	static inline void netif_napi_del(struct napi_struct *napi)
-	{
-	#ifdef CONFIG_NETPOLL
-	        list_del(&napi->dev_list);
-	#endif
-	}
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,27) */
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,31) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32) */
+	static inline
+	struct sk_buff *netdev_alloc_skb_ip_align(struct net_device *dev,
+						  unsigned int length)
+	{
+		struct sk_buff *skb = netdev_alloc_skb(dev, length + NET_IP_ALIGN);
+
+		if (NET_IP_ALIGN && skb)
+			skb_reserve(skb, NET_IP_ALIGN);
+		return skb;
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33) */
+	static inline int usb_enable_autosuspend(struct usb_device *udev)
+	{ return 0; }
+	static inline int usb_disable_autosuspend(struct usb_device *udev)
+	{ return 0; }
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,34) */
+	static inline bool pci_dev_run_wake(struct pci_dev *dev)
+	{
+		return 1;
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35) */
+	static inline void usleep_range(unsigned long min, unsigned long max)
+	{
+		unsigned long ms = min / 1000;
+
+		if (ms)
+			mdelay(ms);
+
+		udelay(min % 1000);
+	}
+
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36) */
+	static inline __be16 vlan_get_protocol(const struct sk_buff *skb)
+	{
+	       __be16 protocol = 0;
+
+	       if (vlan_tx_tag_present(skb) ||
+	            skb->protocol != cpu_to_be16(ETH_P_8021Q))
+	               protocol = skb->protocol;
+	       else {
+	               __be16 proto, *protop;
+	               protop = skb_header_pointer(skb, offsetof(struct vlan_ethhdr,
+	                                               h_vlan_encapsulated_proto),
+	                                               sizeof(proto), &proto);
+	               if (likely(protop))
+	                       protocol = *protop;
+	       }
+
+	       return protocol;
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,39) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,1,0) */
+	static inline struct page *skb_frag_page(const skb_frag_t *frag)
+	{
+		return frag->page;
+	}
+
+	static inline void *skb_frag_address(const skb_frag_t *frag)
+	{
+		return page_address(skb_frag_page(frag)) + frag->page_offset;
+	}
+
+	static inline unsigned int skb_frag_size(const skb_frag_t *frag)
+	{
+		return frag->size;
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,2,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0) */
+	static inline void eth_hw_addr_random(struct net_device *dev)
+	{
+		random_ether_addr(dev->dev_addr);
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0) */
+	static inline __sum16 tcp_v6_check(int len,
+					   const struct in6_addr *saddr,
+					   const struct in6_addr *daddr,
+					   __wsum base)
+	{
+		return csum_ipv6_magic(saddr, daddr, len, IPPROTO_TCP, base);
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,8,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0) */
+	static inline bool usb_device_no_sg_constraint(struct usb_device *udev)
+	{
+		return 0;
+	}
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,12,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,14,0) */
+	static inline int skb_to_sgvec_nomark(struct sk_buff *skb,
+					      struct scatterlist *sg,
+					      int offset, int len)
+	{
+		int nsg = skb_to_sgvec(skb, sg, offset, len);
+
+		if (nsg <= 0)
+			return nsg;
+
+		sg_unmark_end(&sg[nsg - 1]);
+
+		return nsg;
+	}
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,16,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(3,19,0) */
@@ -462,7 +489,34 @@
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,5,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0) */
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) */
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0) */
+	static inline void linkmode_set_bit(int nr, volatile unsigned long *addr)
+	{
+		__set_bit(nr, addr);
+	}
+
+	static inline void linkmode_clear_bit(int nr, volatile unsigned long *addr)
+	{
+		__clear_bit(nr, addr);
+	}
+
+	static inline int linkmode_test_bit(int nr, volatile unsigned long *addr)
+	{
+		return test_bit(nr, addr);
+	}
+
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0) */
+	static inline void linkmode_mod_bit(int nr, volatile unsigned long *addr,
+					    int set)
+	{
+		if (set)
+			linkmode_set_bit(nr, addr);
+		else
+			linkmode_clear_bit(nr, addr);
+	}
+
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0) */
 
 #ifndef FALSE
 	#define TRUE	1

--- a/r8152.c
+++ b/r8152.c
@@ -26,11 +26,12 @@
 #include <net/ip6_checksum.h>
 #include <linux/usb/cdc.h>
 #include <linux/suspend.h>
-
+#include <linux/atomic.h>
+#include <linux/acpi.h>
 #include "compatibility.h"
 
 /* Version Information */
-#define DRIVER_VERSION "v2.12.0 (2019/04/29)"
+#define DRIVER_VERSION "v2.13.0 (2020/04/20)"
 #define DRIVER_AUTHOR "Realtek nic sw <nic_swsd@realtek.com>"
 #define DRIVER_DESC "Realtek RTL8152/RTL8153 Based USB Ethernet Adapters"
 #define MODULENAME "r8152"
@@ -54,15 +55,22 @@
 #define PLA_TEREDO_WAKE_BASE	0xc0c4
 #define PLA_MAR			0xcd00
 #define PLA_BACKUP		0xd000
-#define PAL_BDC_CR		0xd1a0
+#define PLA_BDC_CR		0xd1a0
 #define PLA_TEREDO_TIMER	0xd2cc
 #define PLA_REALWOW_TIMER	0xd2e8
+#define PLA_UPHY_TIMER		0xd388
+#define PLA_SUSPEND_FLAG	0xd38a
+#define PLA_INDICATE_FALG	0xd38c
+#define PLA_MACDBG_PRE		0xd38c	/* RTL_VER_04 only */
+#define PLA_MACDBG_POST		0xd38e	/* RTL_VER_04 only */
+#define PLA_EXTRA_STATUS	0xd398
 #define PLA_EFUSE_DATA		0xdd00
 #define PLA_EFUSE_CMD		0xdd02
 #define PLA_LEDSEL		0xdd90
 #define PLA_LED_FEATURE		0xdd92
 #define PLA_PHYAR		0xde00
 #define PLA_BOOT_CTRL		0xe004
+#define PLA_LWAKE_CTRL_REG	0xe007
 #define PLA_GPHY_INTR_IMR	0xe022
 #define PLA_EEE_CR		0xe040
 #define PLA_EEEP_CR		0xe080
@@ -90,6 +98,7 @@
 #define PLA_TALLYCNT		0xe890
 #define PLA_SFF_STS_7		0xe8de
 #define PLA_PHYSTATUS		0xe908
+#define PLA_CONFIG6		0xe90a /* CONFIG6 */
 #define PLA_BP_BA		0xfc26
 #define PLA_BP_0		0xfc28
 #define PLA_BP_1		0xfc2a
@@ -102,6 +111,7 @@
 #define PLA_BP_EN		0xfc38
 
 #define USB_USB2PHY		0xb41e
+#define USB_SSPHYLINK1		0xb426
 #define USB_SSPHYLINK2		0xb428
 #define USB_U2P3_CTRL		0xb460
 #define USB_CSR_DUMMY1		0xb464
@@ -110,7 +120,13 @@
 #define USB_CONNECT_TIMER	0xcbf8
 #define USB_MSC_TIMER		0xcbfc
 #define USB_BURST_SIZE		0xcfc0
+#define USB_FW_FIX_EN0		0xcfca
+#define USB_FW_FIX_EN1		0xcfcc
 #define USB_LPM_CONFIG		0xcfd8
+#define USB_EFUSE		0xcfdb
+#define USB_CSTMR		0xcfef	/* RTL8153A */
+#define USB_FW_CTRL		0xd334	/* RTL8153B */
+#define USB_FC_TIMER		0xd340
 #define USB_USB_CTRL		0xd406
 #define USB_PHY_CTRL		0xd408
 #define USB_TX_AGG		0xd40a
@@ -126,24 +142,27 @@
 #define USB_LPM_CTRL		0xd41a
 #define USB_BMU_RESET		0xd4b0
 #define USB_U1U2_TIMER		0xd4da
+#define USB_FW_TASK		0xd4e8	/* RTL8153B */
 #define USB_UPS_CTRL		0xd800
 #define USB_POWER_CUT		0xd80a
 #define USB_MISC_0		0xd81a
+#define USB_MISC_1		0xd81f
 #define USB_AFE_CTRL2		0xd824
 #define USB_UPS_CFG		0xd842
 #define USB_UPS_FLAGS		0xd848
+#define USB_WDT1_CTRL		0xe404
 #define USB_WDT11_CTRL		0xe43c
-#define USB_BP_BA		0xfc26
-#define USB_BP_0		0xfc28
-#define USB_BP_1		0xfc2a
-#define USB_BP_2		0xfc2c
-#define USB_BP_3		0xfc2e
-#define USB_BP_4		0xfc30
-#define USB_BP_5		0xfc32
-#define USB_BP_6		0xfc34
-#define USB_BP_7		0xfc36
-#define USB_BP_EN		0xfc38
-#define USB_BP_8		0xfc38
+#define USB_BP_BA		PLA_BP_BA
+#define USB_BP_0		PLA_BP_0
+#define USB_BP_1		PLA_BP_1
+#define USB_BP_2		PLA_BP_2
+#define USB_BP_3		PLA_BP_3
+#define USB_BP_4		PLA_BP_4
+#define USB_BP_5		PLA_BP_5
+#define USB_BP_6		PLA_BP_6
+#define USB_BP_7		PLA_BP_7
+#define USB_BP_EN		PLA_BP_EN	/* RTL8153A */
+#define USB_BP_8		0xfc38		/* RTL8153B */
 #define USB_BP_9		0xfc3a
 #define USB_BP_10		0xfc3c
 #define USB_BP_11		0xfc3e
@@ -174,6 +193,7 @@
 #define OCP_PHY_STATE		0xa708		/* nway state for 8153 */
 #define OCP_PHY_PATCH_STAT	0xb800
 #define OCP_PHY_PATCH_CMD	0xb820
+#define OCP_PHY_LOCK		0xb82e
 #define OCP_ADC_IOFFSET		0xbcfc
 #define OCP_ADC_CFG		0xbc06
 #define OCP_SYSCLK_CFG		0xc416
@@ -184,6 +204,7 @@
 #define SRAM_10M_AMP1		0x8080
 #define SRAM_10M_AMP2		0x8082
 #define SRAM_IMPEDANCE		0x8084
+#define SRAM_PHY_LOCK		0xb82e
 
 /* PLA_RCR */
 #define RCR_AAP			0x00000001
@@ -274,7 +295,7 @@
 #define TEREDO_RS_EVENT_MASK	0x00fe
 #define OOB_TEREDO_EN		0x0001
 
-/* PAL_BDC_CR */
+/* PLA_BDC_CR */
 #define ALDPS_PROXY_MODE	0x0001
 
 /* PLA_EFUSE_CMD */
@@ -284,6 +305,9 @@
 /* PLA_CONFIG34 */
 #define LINK_ON_WAKE_EN		0x0010
 #define LINK_OFF_WAKE_EN	0x0008
+
+/* PLA_CONFIG6 */
+#define LANWAKE_CLR_EN		BIT(0)
 
 /* PLA_CONFIG5 */
 #define BWF_EN			0x0040
@@ -310,6 +334,7 @@
 #define MAC_CLK_SPDWN_EN	BIT(15)
 
 /* PLA_MAC_PWR_CTRL3 */
+#define PLA_MCU_SPDWN_EN	BIT(14)
 #define PKT_AVAIL_SPDWN_EN	0x0100
 #define SUSPEND_SPDWN_EN	0x0004
 #define U1U2_SPDWN_EN		0x0002
@@ -340,9 +365,31 @@
 /* PLA_BOOT_CTRL */
 #define AUTOLOAD_DONE		0x0002
 
+/* PLA_LWAKE_CTRL_REG */
+#define LANWAKE_PIN		BIT(7)
+
+/* PLA_SUSPEND_FLAG */
+#define LINK_CHG_EVENT		BIT(0)
+
+/* PLA_INDICATE_FALG */
+#define UPCOMING_RUNTIME_D3	BIT(0)
+
+/* PLA_MACDBG_PRE and PLA_MACDBG_POST */
+#define DEBUG_OE		BIT(0)
+#define DEBUG_LTSSM		0x0082
+
+/* PLA_EXTRA_STATUS */
+#define CUR_LINK_OK		BIT(15)
+#define U3P3_CHECK_EN		BIT(7)	/* RTL_VER_05 only */
+#define LINK_CHANGE_FLAG	BIT(8)
+#define POLL_LINK_CHG		BIT(0)
+
 /* USB_USB2PHY */
 #define USB2PHY_SUSPEND		0x0001
 #define USB2PHY_L1		0x0002
+
+/* USB_SSPHYLINK1 */
+#define DELAY_PHY_PWR_CHG	BIT(1)
 
 /* USB_SSPHYLINK2 */
 #define pwd_dn_scale_mask	0x3ffe
@@ -359,8 +406,17 @@
 #define STAT_SPEED_HIGH		0x0000
 #define STAT_SPEED_FULL		0x0002
 
+/* USB_FW_FIX_EN0 */
+#define FW_FIX_SUSPEND		BIT(14)
+
+/* USB_FW_FIX_EN1 */
+#define FW_IP_RESET_EN		BIT(9)
+
 /* USB_LPM_CONFIG */
 #define LPM_U1U2_EN		BIT(0)
+
+/* USB_EFUSE */
+#define PASS_THRU_MASK		BIT(0)
 
 /* USB_TX_AGG */
 #define TX_AGG_MAX_THRESHOLD	0x03
@@ -383,11 +439,23 @@
 #define OWN_UPDATE		BIT(0)
 #define OWN_CLEAR		BIT(1)
 
+/* USB_FW_TASK */
+#define FC_PATCH_TASK		BIT(1)
+
 /* USB_UPS_CTRL */
 #define POWER_CUT		0x0100
 
 /* USB_PM_CTRL_STATUS */
 #define RESUME_INDICATE		0x0001
+
+/* USB_CSTMR */
+#define FORCE_SUPER		BIT(0)
+
+/* USB_FW_CTRL */
+#define FLOW_CTRL_PATCH_OPT	BIT(1)
+
+/* USB_FC_TIMER */
+#define CTRL_TIMER_EN		BIT(15)
 
 /* USB_USB_CTRL */
 #define RX_AGG_DISABLE		0x0010
@@ -404,11 +472,19 @@
 
 /* USB_MISC_0 */
 #define PCUT_STATUS		0x0001
+#define AD_MASK			0xfee0
+
+/* USB_MISC_1 */
+#define BD_MASK			BIT(0)
+#define BND_MASK		BIT(2)
 
 /* USB_RX_EARLY_TIMEOUT */
 #define COALESCE_SUPER		 85000U
 #define COALESCE_HIGH		250000U
 #define COALESCE_SLOW		524280U
+
+/* USB_WDT1_CTRL */
+#define WTD1_EN			BIT(0)
 
 /* USB_WDT11_CTRL */
 #define TIMER11_EN		0x0001
@@ -533,6 +609,9 @@ enum spd_duplex {
 /* OCP_PHY_PATCH_CMD */
 #define PATCH_REQUEST		BIT(4)
 
+/* OCP_PHY_LOCK */
+#define PATCH_LOCK		BIT(0)
+
 /* OCP_ADC_CFG */
 #define CKADSEL_L		0x0100
 #define ADC_EN			0x0080
@@ -557,6 +636,9 @@ enum spd_duplex {
 /* SRAM_IMPEDANCE */
 #define RX_DRIVING_MASK		0x6000
 
+/* SRAM_PHY_LOCK */
+#define PHY_PATCH_LOCK		0x0001
+
 enum rtl_register_content {
 	_2500bps	= BIT(10),
 	_1250bps	= BIT(9),
@@ -573,6 +655,9 @@ enum rtl_register_content {
 #define INTBUFSIZE		2
 #define TX_ALIGN		4
 #define RX_ALIGN		8
+
+#define RTL8152_RX_MAX_PENDING	4096
+#define RTL8152_RXFG_HEADSZ	256
 
 #define INTR_LINK		0x0004
 
@@ -594,9 +679,10 @@ enum rtl_register_content {
 #define RTL8152_RMS		(VLAN_ETH_FRAME_LEN + ETH_FCS_LEN)
 #define RTL8153_RMS		RTL8153_MAX_PACKET
 #define RTL8152_TX_TIMEOUT	(5 * HZ)
-#define RTL8152_NAPI_WEIGHT	64
 #define rx_reserved_size(x)	((x) + VLAN_ETH_HLEN + ETH_FCS_LEN + \
 				 sizeof(struct rx_desc) + RX_ALIGN)
+
+#define RTL_MAX_SG_NUM		64
 
 /* rtl8152 flags */
 enum rtl8152_flags {
@@ -609,7 +695,6 @@ enum rtl8152_flags {
 	SCHEDULE_TASKLET,
 	GREEN_ETHERNET,
 	RECOVER_SPEED,
-	SUPPORT_2500FULL,
 };
 
 /* Define these values to match your device */
@@ -617,9 +702,9 @@ enum rtl8152_flags {
 #define VENDOR_ID_MICROSOFT		0x045e
 #define VENDOR_ID_SAMSUNG		0x04e8
 #define VENDOR_ID_LENOVO		0x17ef
-#define VENDOR_ID_TPLINK		0x2357
+#define VENDOR_ID_LINKSYS		0x13b1
 #define VENDOR_ID_NVIDIA		0x0955
-#define VENDOR_ID_TRENDNET		0x20f4
+#define VENDOR_ID_TPLINK		0x2357
 
 #define MCU_TYPE_PLA			0x0100
 #define MCU_TYPE_USB			0x0000
@@ -688,17 +773,18 @@ struct tx_desc {
 struct r8152;
 
 struct rx_agg {
-	struct list_head list;
+	struct list_head list, info_list;
 	struct urb *urb;
 	struct r8152 *context;
+	struct page *page;
 	void *buffer;
-	void *head;
 };
 
 struct tx_agg {
 	struct list_head list;
 	struct urb *urb;
 	struct r8152 *context;
+	struct sk_buff_head tx_skb;
 	void *buffer;
 	void *head;
 	u32 skb_num;
@@ -713,7 +799,7 @@ struct r8152 {
 	struct net_device *netdev;
 	struct urb *intr_urb;
 	struct tx_agg tx_info[RTL8152_MAX_TX];
-	struct rx_agg rx_info[RTL8152_MAX_RX];
+	struct list_head rx_info, rx_used;
 	struct list_head rx_done, tx_free;
 	struct sk_buff_head tx_queue, rx_queue;
 	spinlock_t rx_lock, tx_lock;
@@ -732,18 +818,18 @@ struct r8152 {
 	struct tasklet_struct tx_tl;
 
 	struct rtl_ops {
-		void (*init)(struct r8152 *);
-		int (*enable)(struct r8152 *);
-		void (*disable)(struct r8152 *);
-		void (*up)(struct r8152 *);
-		void (*down)(struct r8152 *);
-		void (*unload)(struct r8152 *);
+		void (*init)(struct r8152 *tp);
+		int (*enable)(struct r8152 *tp);
+		void (*disable)(struct r8152 *tp);
+		void (*up)(struct r8152 *tp);
+		void (*down)(struct r8152 *tp);
+		void (*unload)(struct r8152 *tp);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
-		int (*eee_get)(struct r8152 *, struct ethtool_eee *);
-		int (*eee_set)(struct r8152 *, struct ethtool_eee *);
+		int (*eee_get)(struct r8152 *tp, struct ethtool_eee *eee);
+		int (*eee_set)(struct r8152 *tp, struct ethtool_eee *eee);
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0) */
-		bool (*in_nway)(struct r8152 *);
-		void (*hw_phy_cfg)(struct r8152 *);
+		bool (*in_nway)(struct r8152 *tp);
+		void (*hw_phy_cfg)(struct r8152 *tp);
 		void (*autosuspend_en)(struct r8152 *tp, bool enable);
 	} rtl_ops;
 
@@ -764,6 +850,8 @@ struct r8152 {
 		u32 ctap_short_off:1;
 	} ups_info;
 
+	atomic_t rx_count;
+
 	bool eee_en;
 	int intr_interval;
 	u32 saved_wolopts;
@@ -772,6 +860,15 @@ struct r8152 {
 	u32 coalesce;
 	u32 advertising;
 	u32 rx_buf_sz;
+	u32 rx_copybreak;
+	u32 rx_pending;
+	u32 fc_pause, fc_restart;
+
+	u32 support_2500full:1;
+	u32 sg_use:1;
+//	u32 dash_mode:1;
+	u32 lenovo_macpassthru:1;
+
 	u16 ocp_base;
 	u16 speed;
 	u16 eee_adv;
@@ -797,6 +894,8 @@ enum rtl_version {
 	RTL_TEST_01,
 	RTL_VER_10,
 	RTL_VER_11,
+	RTL_VER_12,
+	RTL_VER_13,
 
 	RTL_VER_MAX
 };
@@ -806,6 +905,14 @@ enum tx_csum_stat {
 	TX_CSUM_TSO,
 	TX_CSUM_NONE
 };
+
+#define RTL_ADVERTISED_10_HALF			BIT(0)
+#define RTL_ADVERTISED_10_FULL			BIT(1)
+#define RTL_ADVERTISED_100_HALF			BIT(2)
+#define RTL_ADVERTISED_100_FULL			BIT(3)
+#define RTL_ADVERTISED_1000_HALF		BIT(4)
+#define RTL_ADVERTISED_1000_FULL		BIT(5)
+#define RTL_ADVERTISED_2500_FULL		BIT(6)
 
 /* Maximum number of multicast addresses to filter (vs. Rx-all-multicast).
  * The RTL chips use a 64 element hash table based on the Ethernet CRC.
@@ -836,6 +943,12 @@ int get_registers(struct r8152 *tp, u16 value, u16 index, u16 size, void *data)
 
 	kfree(tmp);
 
+	if (ret < 0) {
+		if (ret == -ETIMEDOUT)
+			usb_queue_reset_device(tp->intf);
+		netif_err(tp, drv, tp->netdev, "get_registers %d\n", ret);
+	}
+
 	return ret;
 }
 
@@ -854,6 +967,12 @@ int set_registers(struct r8152 *tp, u16 value, u16 index, u16 size, void *data)
 			      value, index, tmp, size, 500);
 
 	kfree(tmp);
+
+	if (ret < 0) {
+		if (ret == -ETIMEDOUT)
+			usb_queue_reset_device(tp->intf);
+		netif_err(tp, drv, tp->netdev, "set_registers %d\n", ret);
+	}
 
 	return ret;
 }
@@ -1230,33 +1349,134 @@ out1:
 	return ret;
 }
 
+/* Devices containing proper chips can support a persistent
+ * host system provided MAC address.
+ * Examples of this are Dell TB15 and Dell WD15 docks
+ */
+static int vendor_mac_passthru_addr_read(struct r8152 *tp, struct sockaddr *sa)
+{
+	acpi_status status;
+	struct acpi_buffer buffer = { ACPI_ALLOCATE_BUFFER, NULL };
+	union acpi_object *obj;
+	int ret = -EINVAL;
+	u32 ocp_data;
+	unsigned char buf[6];
+	char *mac_obj_name;
+	acpi_object_type mac_obj_type;
+	int mac_strlen;
+
+	if (tp->lenovo_macpassthru) {
+		mac_obj_name = "\\MACA";
+		mac_obj_type = ACPI_TYPE_STRING;
+		mac_strlen = 0x16;
+	} else {
+		/* test for -AD variant of RTL8153 */
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_MISC_0);
+		if ((ocp_data & AD_MASK) == 0x1000) {
+			/* test for MAC address pass-through bit */
+			ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, USB_EFUSE);
+			if ((ocp_data & PASS_THRU_MASK) != 1) {
+				netif_dbg(tp, probe, tp->netdev,
+						"No efuse for RTL8153-AD MAC pass through\n");
+				return -ENODEV;
+			}
+		} else {
+			/* test for RTL8153-BND and RTL8153-BD */
+			ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, USB_MISC_1);
+			if ((ocp_data & BND_MASK) == 0 && (ocp_data & BD_MASK) == 0) {
+				netif_dbg(tp, probe, tp->netdev,
+						"Invalid variant for MAC pass through\n");
+				return -ENODEV;
+			}
+		}
+
+		mac_obj_name = "\\_SB.AMAC";
+		mac_obj_type = ACPI_TYPE_BUFFER;
+		mac_strlen = 0x17;
+	}
+
+	/* returns _AUXMAC_#AABBCCDDEEFF# */
+	status = acpi_evaluate_object(NULL, mac_obj_name, NULL, &buffer);
+	obj = (union acpi_object *)buffer.pointer;
+	if (!ACPI_SUCCESS(status))
+		return -ENODEV;
+	if (obj->type != mac_obj_type || obj->string.length != mac_strlen) {
+		netif_warn(tp, probe, tp->netdev,
+			   "Invalid buffer for pass-thru MAC addr: (%d, %d)\n",
+			   obj->type, obj->string.length);
+		goto amacout;
+	}
+
+	if (strncmp(obj->string.pointer, "_AUXMAC_#", 9) != 0 ||
+	    strncmp(obj->string.pointer + 0x15, "#", 1) != 0) {
+		netif_warn(tp, probe, tp->netdev,
+			   "Invalid header when reading pass-thru MAC addr\n");
+		goto amacout;
+	}
+	ret = hex2bin(buf, obj->string.pointer + 9, 6);
+	if (!(ret == 0 && is_valid_ether_addr(buf))) {
+		netif_warn(tp, probe, tp->netdev,
+			   "Invalid MAC for pass-thru MAC addr: %d, %pM\n",
+			   ret, buf);
+		ret = -EINVAL;
+		goto amacout;
+	}
+	memcpy(sa->sa_data, buf, 6);
+	netif_info(tp, probe, tp->netdev,
+		   "Using pass-thru MAC addr %pM\n", sa->sa_data);
+
+amacout:
+	kfree(obj);
+	return ret;
+}
+
+static int determine_ethernet_addr(struct r8152 *tp, struct sockaddr *sa)
+{
+	struct net_device *dev = tp->netdev;
+	int ret;
+
+	sa->sa_family = dev->type;
+
+	if (tp->version == RTL_VER_01) {
+		ret = pla_ocp_read(tp, PLA_IDR, 8, sa->sa_data);
+	} else {
+		/* if device doesn't support MAC pass through this will
+		 * be expected to be non-zero
+		 */
+		ret = vendor_mac_passthru_addr_read(tp, sa);
+		if (ret < 0)
+			ret = pla_ocp_read(tp, PLA_BACKUP, 8, sa->sa_data);
+	}
+
+	if (ret < 0) {
+		netif_err(tp, probe, dev, "Get ether addr fail\n");
+	} else if (!is_valid_ether_addr(sa->sa_data)) {
+		netif_err(tp, probe, dev, "Invalid ether addr %pM\n",
+			  sa->sa_data);
+		eth_hw_addr_random(dev);
+		ether_addr_copy(sa->sa_data, dev->dev_addr);
+		netif_info(tp, probe, dev, "Random ether addr %pM\n",
+			   sa->sa_data);
+		return 0;
+	}
+
+	return ret;
+}
+
 static int set_ethernet_addr(struct r8152 *tp)
 {
 	struct net_device *dev = tp->netdev;
 	struct sockaddr sa;
 	int ret;
 
-	if (tp->version == RTL_VER_01)
-		ret = pla_ocp_read(tp, PLA_IDR, 8, sa.sa_data);
-	else
-		ret = pla_ocp_read(tp, PLA_BACKUP, 8, sa.sa_data);
+	ret = determine_ethernet_addr(tp, &sa);
+	if (ret < 0)
+		return ret;
 
-	if (ret < 0) {
-		netif_err(tp, probe, dev, "Get ether addr fail\n");
-	} else if (!is_valid_ether_addr(sa.sa_data)) {
-		netif_err(tp, probe, dev, "Invalid ether addr %pM\n",
-			  sa.sa_data);
-		eth_hw_addr_random(dev);
-		ether_addr_copy(sa.sa_data, dev->dev_addr);
+	if (tp->version == RTL_VER_01)
+		ether_addr_copy(dev->dev_addr, sa.sa_data);
+	else
 		ret = rtl8152_set_mac_address(dev, &sa);
-		netif_info(tp, probe, dev, "Random ether addr %pM\n",
-			   sa.sa_data);
-	} else {
-		if (tp->version == RTL_VER_01)
-			ether_addr_copy(dev->dev_addr, sa.sa_data);
-		else
-			ret = rtl8152_set_mac_address(dev, &sa);
-	}
 
 	return ret;
 }
@@ -1382,6 +1602,59 @@ static void write_bulk_callback(struct urb *urb)
 		tasklet_schedule(&tp->tx_tl);
 }
 
+static void write_bulk_sg_callback(struct urb *urb)
+{
+	struct net_device *netdev;
+	struct tx_agg *agg;
+	struct r8152 *tp;
+	unsigned long flags;
+	int status = urb->status;
+
+	agg = urb->context;
+	if (!agg)
+		return;
+
+	tp = agg->context;
+	if (!tp)
+		return;
+
+	netdev = tp->netdev;
+	if (status && net_ratelimit())
+		netif_warn(tp, tx_err, netdev, "Tx status %d\n", status);
+
+	while (!skb_queue_empty(&agg->tx_skb)) {
+		struct sk_buff *skb = __skb_dequeue(&agg->tx_skb);
+		struct net_device_stats *stats = rtl8152_get_stats(netdev);
+
+		if (status) {
+			stats->tx_errors += skb_shinfo(skb)->gso_segs ?: 1;
+			dev_kfree_skb_any(skb);
+		} else {
+			stats->tx_packets += skb_shinfo(skb)->gso_segs ?: 1;
+			stats->tx_bytes += skb->len - skb->cb[0];
+			dev_consume_skb_any(skb);
+		}
+	}
+
+	spin_lock_irqsave(&tp->tx_lock, flags);
+	list_add_tail(&agg->list, &tp->tx_free);
+	spin_unlock_irqrestore(&tp->tx_lock, flags);
+
+	usb_autopm_put_interface_async(tp->intf);
+
+	if (!netif_carrier_ok(netdev))
+		return;
+
+	if (!test_bit(WORK_ENABLE, &tp->flags))
+		return;
+
+	if (test_bit(RTL8152_UNPLUG, &tp->flags))
+		return;
+
+	if (!skb_queue_empty(&tp->tx_queue))
+		tasklet_schedule(&tp->tx_tl);
+}
+
 static void intr_callback(struct urb *urb)
 {
 	struct r8152 *tp;
@@ -1405,6 +1678,7 @@ static void intr_callback(struct urb *urb)
 	case -ECONNRESET:	/* unlink */
 	case -ESHUTDOWN:
 		netif_device_detach(tp->netdev);
+		/* fall through */
 	case -ENOENT:
 	case -EPROTO:
 		netif_info(tp, intr, tp->netdev,
@@ -1454,18 +1728,72 @@ static inline void *tx_agg_align(void *data)
 	return (void *)ALIGN((uintptr_t)data, TX_ALIGN);
 }
 
+static void free_rx_agg(struct r8152 *tp, struct rx_agg *agg)
+{
+	list_del(&agg->info_list);
+
+	usb_free_urb(agg->urb);
+	put_page(agg->page);
+	kfree(agg);
+
+	atomic_dec(&tp->rx_count);
+}
+
+static struct rx_agg *alloc_rx_agg(struct r8152 *tp, gfp_t mflags)
+{
+	struct net_device *netdev = tp->netdev;
+	int node = netdev->dev.parent ? dev_to_node(netdev->dev.parent) : -1;
+	unsigned int order = get_order(tp->rx_buf_sz);
+	struct rx_agg *rx_agg;
+	unsigned long flags;
+
+	rx_agg = kmalloc_node(sizeof(*rx_agg), mflags, node);
+	if (!rx_agg)
+		return NULL;
+
+	rx_agg->page = alloc_pages(mflags | __GFP_COMP, order);
+	if (!rx_agg->page)
+		goto free_rx;
+
+	rx_agg->buffer = page_address(rx_agg->page);
+
+	rx_agg->urb = usb_alloc_urb(0, mflags);
+	if (!rx_agg->urb)
+		goto free_buf;
+
+	rx_agg->context = tp;
+
+	INIT_LIST_HEAD(&rx_agg->list);
+	INIT_LIST_HEAD(&rx_agg->info_list);
+	spin_lock_irqsave(&tp->rx_lock, flags);
+	list_add_tail(&rx_agg->info_list, &tp->rx_info);
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
+
+	atomic_inc(&tp->rx_count);
+
+	return rx_agg;
+
+free_buf:
+	__free_pages(rx_agg->page, order);
+free_rx:
+	kfree(rx_agg);
+	return NULL;
+}
+
 static void free_all_mem(struct r8152 *tp)
 {
+	struct rx_agg *agg, *agg_next;
+	unsigned long flags;
 	int i;
 
-	for (i = 0; i < RTL8152_MAX_RX; i++) {
-		usb_free_urb(tp->rx_info[i].urb);
-		tp->rx_info[i].urb = NULL;
+	spin_lock_irqsave(&tp->rx_lock, flags);
 
-		kfree(tp->rx_info[i].buffer);
-		tp->rx_info[i].buffer = NULL;
-		tp->rx_info[i].head = NULL;
-	}
+	list_for_each_entry_safe(agg, agg_next, &tp->rx_info, info_list)
+		free_rx_agg(tp, agg);
+
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
+
+	WARN_ON(atomic_read(&tp->rx_count));
 
 	for (i = 0; i < RTL8152_MAX_TX; i++) {
 		usb_free_urb(tp->tx_info[i].urb);
@@ -1489,46 +1817,28 @@ static int alloc_all_mem(struct r8152 *tp)
 	struct usb_interface *intf = tp->intf;
 	struct usb_host_interface *alt = intf->cur_altsetting;
 	struct usb_host_endpoint *ep_intr = alt->endpoint + 2;
-	struct urb *urb;
 	int node, i;
-	u8 *buf;
 
 	node = netdev->dev.parent ? dev_to_node(netdev->dev.parent) : -1;
 
 	spin_lock_init(&tp->rx_lock);
 	spin_lock_init(&tp->tx_lock);
+	INIT_LIST_HEAD(&tp->rx_info);
 	INIT_LIST_HEAD(&tp->tx_free);
 	INIT_LIST_HEAD(&tp->rx_done);
 	skb_queue_head_init(&tp->tx_queue);
 	skb_queue_head_init(&tp->rx_queue);
+	atomic_set(&tp->rx_count, 0);
 
 	for (i = 0; i < RTL8152_MAX_RX; i++) {
-		buf = kmalloc_node(tp->rx_buf_sz, GFP_KERNEL, node);
-		if (!buf)
+		if (!alloc_rx_agg(tp, GFP_KERNEL))
 			goto err1;
-
-		if (buf != rx_agg_align(buf)) {
-			kfree(buf);
-			buf = kmalloc_node(tp->rx_buf_sz + RX_ALIGN, GFP_KERNEL,
-					   node);
-			if (!buf)
-				goto err1;
-		}
-
-		urb = usb_alloc_urb(0, GFP_KERNEL);
-		if (!urb) {
-			kfree(buf);
-			goto err1;
-		}
-
-		INIT_LIST_HEAD(&tp->rx_info[i].list);
-		tp->rx_info[i].context = tp;
-		tp->rx_info[i].urb = urb;
-		tp->rx_info[i].buffer = buf;
-		tp->rx_info[i].head = rx_agg_align(buf);
 	}
 
 	for (i = 0; i < RTL8152_MAX_TX; i++) {
+		struct urb *urb;
+		u8 *buf;
+
 		buf = kmalloc_node(agg_buf_sz, GFP_KERNEL, node);
 		if (!buf)
 			goto err1;
@@ -1554,6 +1864,7 @@ static int alloc_all_mem(struct r8152 *tp)
 		tp->tx_info[i].head = tx_agg_align(buf);
 
 		list_add_tail(&tp->tx_info[i].list, &tp->tx_free);
+		skb_queue_head_init(&tp->tx_info[i].tx_skb);
 	}
 
 	tp->intr_urb = usb_alloc_urb(0, GFP_KERNEL);
@@ -1598,7 +1909,7 @@ static struct tx_agg *r8152_get_tx_agg(struct r8152 *tp)
 }
 
 /* r8152_csum_workaround()
- * The hw limites the value the transport offset. When the offset is out of the
+ * The hw limits the value of the transport offset. When the offset is out of
  * range, calculate the checksum by sw.
  */
 static void r8152_csum_workaround(struct r8152 *tp, struct sk_buff *skb,
@@ -1874,7 +2185,7 @@ static int r8152_tx_agg_fill(struct r8152 *tp, struct tx_agg *agg)
 		agg->skb_len += len;
 		agg->skb_num += skb_shinfo(skb)->gso_segs ?: 1;
 
-		dev_kfree_skb_any(skb);
+		dev_consume_skb_any(skb);
 
 		remain = agg_buf_sz - (int)(tx_agg_align(tx_data) - agg->head);
 	}
@@ -1900,6 +2211,153 @@ static int r8152_tx_agg_fill(struct r8152 *tp, struct tx_agg *agg)
 	usb_fill_bulk_urb(agg->urb, tp->udev, usb_sndbulkpipe(tp->udev, 2),
 			  agg->head, (int)(tx_data - (u8 *)agg->head),
 			  (usb_complete_t)write_bulk_callback, agg);
+
+	agg->urb->sg = NULL;
+	agg->urb->num_sgs = 0;
+
+	ret = usb_submit_urb(agg->urb, GFP_ATOMIC);
+	if (ret < 0)
+		usb_autopm_put_interface_async(tp->intf);
+
+out_tx_fill:
+	return ret;
+}
+
+static int r8152_tx_agg_sg_fill(struct r8152 *tp, struct tx_agg *agg)
+{
+	struct sk_buff_head skb_head, *tx_queue = &tp->tx_queue;
+	int max_sg_num, ret, sg_num;
+	struct scatterlist *sg;
+	int padding = 0;
+
+	__skb_queue_head_init(&skb_head);
+	spin_lock(&tx_queue->lock);
+	skb_queue_splice_init(tx_queue, &skb_head);
+	spin_unlock(&tx_queue->lock);
+
+	sg = agg->head;
+	max_sg_num = (agg_buf_sz / sizeof(*sg)) - 1;
+	max_sg_num = min_t(int, RTL_MAX_SG_NUM, max_sg_num);
+	sg_init_table(sg, max_sg_num + 1);
+	agg->skb_num = 0;
+	agg->skb_len = 0;
+
+	for (sg_num = 0; sg_num < max_sg_num;) {
+		struct tx_desc tx_desc;
+		struct sk_buff *skb;
+		int num_sgs, headroom;
+		unsigned int len;
+		u32 offset;
+
+		skb = __skb_dequeue(&skb_head);
+		if (!skb)
+			break;
+
+		headroom = skb_headroom(skb) - padding - sizeof(tx_desc);
+
+		if (skb_header_cloned(skb) || headroom < 0) {
+			struct sk_buff *tx_skb;
+
+			headroom = padding + sizeof(tx_desc);
+			tx_skb = skb_copy_expand(skb, headroom, 0, GFP_ATOMIC);
+			dev_kfree_skb_any(skb);
+			if (!tx_skb) {
+				struct net_device_stats *stats;
+
+				stats = rtl8152_get_stats(tp->netdev);
+				stats->tx_dropped++;
+				netif_wake_queue(tp->netdev);
+				return NETDEV_TX_OK;
+			}
+			skb = tx_skb;
+			headroom = skb_headroom(skb) - headroom;
+		}
+
+		 /* calculate the fragment numbers for skb */
+		num_sgs = 1 + skb_shinfo(skb)->nr_frags;
+		len = skb->len;
+
+		if ((num_sgs + sg_num) > max_sg_num) {
+			__skb_queue_head(&skb_head, skb);
+			break;
+		}
+
+		offset = (u32)skb_transport_offset(skb);
+
+		if (r8152_tx_csum(tp, &tx_desc, skb, len, offset)) {
+			r8152_csum_workaround(tp, skb, &skb_head);
+			continue;
+		}
+
+		rtl_tx_vlan_tag(&tx_desc, skb);
+
+		WARN_ON(padding < 0);
+
+		/* use skb_headroom for tx desc */
+		skb->cb[0] = padding + sizeof(tx_desc);
+		memcpy(skb_push(skb, sizeof(tx_desc)), &tx_desc,
+		       sizeof(tx_desc));
+		if (padding)
+			memset(skb_push(skb, padding), 0, padding);
+
+		num_sgs = skb_to_sgvec_nomark(skb, sg, 0, skb->len);
+		if (num_sgs < 0) {
+			netif_err(tp, tx_err, tp->netdev,
+				  "skb_to_sgvec fail %d\n", num_sgs);
+			__skb_queue_head(&skb_head, skb);
+			break;
+		}
+
+		sg += num_sgs;
+
+		__skb_queue_tail(&agg->tx_skb, skb);
+
+		sg_num += num_sgs;
+		agg->skb_len += skb->len;
+		padding = len + sizeof(tx_desc);
+
+		agg->skb_num++;
+
+		padding = ALIGN(padding, TX_ALIGN) - padding;
+	}
+
+	sg_mark_end(sg);
+
+	if (!skb_queue_empty(&skb_head)) {
+		spin_lock(&tx_queue->lock);
+		skb_queue_splice(&skb_head, tx_queue);
+		spin_unlock(&tx_queue->lock);
+	}
+
+	netif_tx_lock(tp->netdev);
+
+	if (netif_queue_stopped(tp->netdev) &&
+	    skb_queue_len(&tp->tx_queue) < tp->tx_qlen)
+		netif_wake_queue(tp->netdev);
+
+	netif_tx_unlock(tp->netdev);
+
+	if (sg_num == 0) {
+		unsigned long flags;
+
+		spin_lock_irqsave(&tp->tx_lock, flags);
+		list_add_tail(&agg->list, &tp->tx_free);
+		spin_unlock_irqrestore(&tp->tx_lock, flags);
+
+		ret = 0;
+		goto out_tx_fill;
+	}
+
+	ret = usb_autopm_get_interface_async(tp->intf);
+	if (ret < 0)
+		goto out_tx_fill;
+
+	usb_fill_bulk_urb(agg->urb, tp->udev, usb_sndbulkpipe(tp->udev, 2),
+			  NULL, (int)agg->skb_len,
+			  (usb_complete_t)write_bulk_sg_callback, agg);
+
+	agg->urb->sg = agg->head;
+	agg->urb->num_sgs = sg_num;
 
 	ret = usb_submit_urb(agg->urb, GFP_ATOMIC);
 	if (ret < 0)
@@ -1936,6 +2394,46 @@ static u8 r8152_rx_csum(struct r8152 *tp, struct rx_desc *rx_desc)
 
 return_result:
 	return checksum;
+}
+
+static inline bool rx_count_exceed(struct r8152 *tp)
+{
+	return atomic_read(&tp->rx_count) > RTL8152_MAX_RX;
+}
+
+static inline int agg_offset(struct rx_agg *agg, void *addr)
+{
+	return (int)(addr - agg->buffer);
+}
+
+static struct rx_agg *rtl_get_free_rx(struct r8152 *tp, gfp_t mflags)
+{
+	struct rx_agg *agg, *agg_next, *agg_free = NULL;
+	unsigned long flags;
+
+	spin_lock_irqsave(&tp->rx_lock, flags);
+
+	list_for_each_entry_safe(agg, agg_next, &tp->rx_used, list) {
+		if (page_count(agg->page) == 1) {
+			if (!agg_free) {
+				list_del_init(&agg->list);
+				agg_free = agg;
+				continue;
+			}
+			if (rx_count_exceed(tp)) {
+				list_del_init(&agg->list);
+				free_rx_agg(tp, agg);
+			}
+			break;
+		}
+	}
+
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
+
+	if (!agg_free && atomic_read(&tp->rx_count) < tp->rx_pending)
+		agg_free = alloc_rx_agg(tp, mflags);
+
+	return agg_free;
 }
 
 static int rx_bottom(struct r8152 *tp, int budget)
@@ -1992,7 +2490,7 @@ static int rx_bottom(struct r8152 *tp, int budget)
 
 	list_for_each_safe(cursor, next, &rx_queue) {
 		struct rx_desc *rx_desc;
-		struct rx_agg *agg;
+		struct rx_agg *agg, *agg_free;
 		int len_used = 0;
 		struct urb *urb;
 		u8 *rx_data;
@@ -2004,14 +2502,16 @@ static int rx_bottom(struct r8152 *tp, int budget)
 		if (urb->actual_length < ETH_ZLEN)
 			goto submit;
 
-		rx_desc = agg->head;
-		rx_data = agg->head;
+		agg_free = rtl_get_free_rx(tp, GFP_ATOMIC);
+
+		rx_desc = agg->buffer;
+		rx_data = agg->buffer;
 		len_used += sizeof(struct rx_desc);
 
 		while (urb->actual_length > len_used) {
 			struct net_device *netdev = tp->netdev;
 			struct net_device_stats *stats;
-			unsigned int pkt_len;
+			unsigned int pkt_len, rx_frag_head_sz;
 			struct sk_buff *skb;
 
 			/* limite the skb numbers for rx_queue */
@@ -2031,15 +2531,30 @@ static int rx_bottom(struct r8152 *tp, int budget)
 			pkt_len -= ETH_FCS_LEN;
 			rx_data += sizeof(struct rx_desc);
 
-			skb = napi_alloc_skb(napi, pkt_len);
+			if (!agg_free || tp->rx_copybreak > pkt_len)
+				rx_frag_head_sz = pkt_len;
+			else
+				rx_frag_head_sz = tp->rx_copybreak;
+
+			skb = napi_alloc_skb(napi, rx_frag_head_sz);
 			if (!skb) {
 				stats->rx_dropped++;
 				goto find_next_rx;
 			}
 
 			skb->ip_summed = r8152_rx_csum(tp, rx_desc);
-			memcpy(skb->data, rx_data, pkt_len);
-			skb_put(skb, pkt_len);
+			memcpy(skb->data, rx_data, rx_frag_head_sz);
+			skb_put(skb, rx_frag_head_sz);
+			pkt_len -= rx_frag_head_sz;
+			rx_data += rx_frag_head_sz;
+			if (pkt_len) {
+				skb_add_rx_frag(skb, 0, agg->page,
+						agg_offset(agg, rx_data),
+						pkt_len,
+						SKB_DATA_ALIGN(pkt_len));
+				get_page(agg->page);
+			}
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)
 			skb->dev = netdev;
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22) */
@@ -2054,7 +2569,7 @@ static int rx_bottom(struct r8152 *tp, int budget)
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29) */
 				work_done++;
 				stats->rx_packets++;
-				stats->rx_bytes += pkt_len;
+				stats->rx_bytes += skb->len;
 			} else {
 				rtl_vlan_put_tag(tp, rx_desc, skb);
 				__skb_queue_tail(&tp->rx_queue, skb);
@@ -2062,10 +2577,10 @@ static int rx_bottom(struct r8152 *tp, int budget)
 #else
 			rtl_rx_vlan_tag(rx_desc, skb);
 			if (work_done < budget) {
-				napi_gro_receive(napi, skb);
 				work_done++;
 				stats->rx_packets++;
-				stats->rx_bytes += pkt_len;
+				stats->rx_bytes += skb->len;
+				napi_gro_receive(napi, skb);
 			} else {
 				__skb_queue_tail(&tp->rx_queue, skb);
 			}
@@ -2074,8 +2589,22 @@ static int rx_bottom(struct r8152 *tp, int budget)
 find_next_rx:
 			rx_data = rx_agg_align(rx_data + pkt_len + ETH_FCS_LEN);
 			rx_desc = (struct rx_desc *)rx_data;
-			len_used = (int)(rx_data - (u8 *)agg->head);
+			len_used = agg_offset(agg, rx_data);
 			len_used += sizeof(struct rx_desc);
+		}
+
+		WARN_ON(!agg_free && page_count(agg->page) > 1);
+
+		if (agg_free) {
+			spin_lock_irqsave(&tp->rx_lock, flags);
+			if (page_count(agg->page) == 1) {
+				list_add(&agg_free->list, &tp->rx_used);
+			} else {
+				list_add_tail(&agg->list, &tp->rx_used);
+				agg = agg_free;
+				urb = agg->urb;
+			}
+			spin_unlock_irqrestore(&tp->rx_lock, flags);
 		}
 
 submit:
@@ -2102,6 +2631,7 @@ static void tx_bottom(struct r8152 *tp)
 	int res;
 
 	do {
+		struct net_device *netdev = tp->netdev;
 		struct tx_agg *agg;
 
 		if (skb_queue_empty(&tp->tx_queue))
@@ -2111,26 +2641,28 @@ static void tx_bottom(struct r8152 *tp)
 		if (!agg)
 			break;
 
-		res = r8152_tx_agg_fill(tp, agg);
-		if (res) {
-			struct net_device *netdev = tp->netdev;
+		if (tp->sg_use)
+			res = r8152_tx_agg_sg_fill(tp, agg);
+		else
+			res = r8152_tx_agg_fill(tp, agg);
 
-			if (res == -ENODEV) {
-				rtl_set_unplug(tp);
-				netif_device_detach(netdev);
-			} else {
-				struct net_device_stats *stats;
-				unsigned long flags;
+		if (!res)
+			continue;
 
-				stats = rtl8152_get_stats(netdev);
-				netif_warn(tp, tx_err, netdev,
-					   "failed tx_urb %d\n", res);
-				stats->tx_dropped += agg->skb_num;
+		if (res == -ENODEV) {
+			rtl_set_unplug(tp);
+			netif_device_detach(netdev);
+		} else {
+			struct net_device_stats *stats = &netdev->stats;
+			unsigned long flags;
 
-				spin_lock_irqsave(&tp->tx_lock, flags);
-				list_add_tail(&agg->list, &tp->tx_free);
-				spin_unlock_irqrestore(&tp->tx_lock, flags);
-			}
+			netif_warn(tp, tx_err, netdev,
+				   "failed tx_urb %d\n", res);
+			stats->tx_dropped += agg->skb_num;
+
+			spin_lock_irqsave(&tp->tx_lock, flags);
+			list_add_tail(&agg->list, &tp->tx_free);
+			spin_unlock_irqrestore(&tp->tx_lock, flags);
 		}
 	} while (res == 0);
 }
@@ -2219,7 +2751,7 @@ int r8152_submit_rx(struct r8152 *tp, struct rx_agg *agg, gfp_t mem_flags)
 		return 0;
 
 	usb_fill_bulk_urb(agg->urb, tp->udev, usb_rcvbulkpipe(tp->udev, 1),
-			  agg->head, tp->rx_buf_sz,
+			  agg->buffer, tp->rx_buf_sz,
 			  (usb_complete_t)read_bulk_callback, agg);
 
 	ret = usb_submit_urb(agg->urb, mem_flags);
@@ -2264,7 +2796,11 @@ static void rtl_drop_queued_tx(struct r8152 *tp)
 	}
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
 static void rtl8152_tx_timeout(struct net_device *netdev)
+#else
+static void rtl8152_tx_timeout(struct net_device *netdev, unsigned int txqueue)
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0) */
 {
 	struct r8152 *tp = netdev_priv(netdev);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29)
@@ -2356,6 +2892,19 @@ static void rtl8152_set_rx_mode(struct net_device *netdev)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,4)
+
+static inline bool rtl_gso_check(struct net_device *dev, struct sk_buff *skb)
+{
+	struct r8152 *tp = netdev_priv(dev);
+
+	if (tp->sg_use)
+		return true;
+	else if ((skb->len + sizeof(struct tx_desc)) <= agg_buf_sz)
+		return true;
+	else
+		return false;
+}
+
 static netdev_features_t
 rtl8152_features_check(struct sk_buff *skb, struct net_device *dev,
 		       netdev_features_t features)
@@ -2366,7 +2915,7 @@ rtl8152_features_check(struct sk_buff *skb, struct net_device *dev,
 
 	if ((mss || skb->ip_summed == CHECKSUM_PARTIAL) && offset > max_offset)
 		features &= ~(NETIF_F_CSUM_MASK | NETIF_F_GSO_MASK);
-	else if ((skb->len + sizeof(struct tx_desc)) > agg_buf_sz)
+	else if (!rtl_gso_check(dev, skb))
 		features &= ~NETIF_F_GSO_MASK;
 
 	return features;
@@ -2379,7 +2928,7 @@ static netdev_tx_t rtl8152_start_xmit(struct sk_buff *skb,
 	struct r8152 *tp = netdev_priv(netdev);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,4)
-	if (unlikely((skb->len + sizeof(struct tx_desc)) > agg_buf_sz)) {
+	if (unlikely(!rtl_gso_check(netdev, skb)) {
 		netdev_features_t features = netdev->features;
 		struct sk_buff *segs, *nskb;
 
@@ -2426,7 +2975,7 @@ free_skb:
 
 static void r8152b_reset_packet_filter(struct r8152 *tp)
 {
-	u32	ocp_data;
+	u32 ocp_data;
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_FMC);
 	ocp_data &= ~FMC_FCR_MCU_EN;
@@ -2437,14 +2986,58 @@ static void r8152b_reset_packet_filter(struct r8152 *tp)
 
 static void rtl8152_nic_reset(struct r8152 *tp)
 {
-	int	i;
+	u32 ocp_data;
+	int i;
 
-	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, CR_RST);
+	switch (tp->version) {
+	case RTL_TEST_01:
+	case RTL_VER_10:
+	case RTL_VER_11:
+		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CR);
+		ocp_data &= ~CR_TE;
+		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		if (!(ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CR) & CR_RST))
-			break;
-		usleep_range(100, 400);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4b0);
+		ocp_data &= ~BIT(0);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd4b0, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd406);
+		ocp_data |= BIT(3);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd406, ocp_data);
+
+		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CR);
+		ocp_data &= ~CR_RE;
+		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4b0);
+		ocp_data |= BIT(0);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd4b0, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd406);
+		ocp_data &= ~BIT(3);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd406, ocp_data);
+		break;
+
+	case RTL_VER_01:
+	case RTL_VER_02:
+	case RTL_VER_03:
+	case RTL_VER_04:
+	case RTL_VER_05:
+	case RTL_VER_06:
+	case RTL_VER_07:
+	case RTL_VER_08:
+	case RTL_VER_09:
+	case RTL_VER_12:
+	case RTL_VER_13:
+	default:
+		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, CR_RST);
+
+		for (i = 0; i < 1000; i++) {
+			if (!(ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CR) & CR_RST))
+				break;
+			usleep_range(100, 400);
+		}
+		break;
 	}
 }
 
@@ -2452,8 +3045,12 @@ static void set_tx_qlen(struct r8152 *tp)
 {
 	struct net_device *netdev = tp->netdev;
 
-	tp->tx_qlen = agg_buf_sz / (netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN +
-				    sizeof(struct tx_desc));
+	if (tp->sg_use)
+		tp->tx_qlen = RTL_MAX_SG_NUM;
+	else
+		tp->tx_qlen = agg_buf_sz / (netdev->mtu + VLAN_ETH_HLEN +
+					    ETH_FCS_LEN +
+					    sizeof(struct tx_desc));
 }
 
 static inline u16 rtl8152_get_speed(struct r8152 *tp)
@@ -2516,44 +3113,80 @@ static int rtl_s5_wol(struct r8152 *tp)
 
 static int rtl_start_rx(struct r8152 *tp)
 {
-	int i, ret = 0;
+	struct rx_agg *agg, *agg_next;
+	struct list_head tmp_list;
+	unsigned long flags;
+	int ret = 0, i = 0;
+
+	INIT_LIST_HEAD(&tmp_list);
+
+	spin_lock_irqsave(&tp->rx_lock, flags);
 
 	INIT_LIST_HEAD(&tp->rx_done);
-	for (i = 0; i < RTL8152_MAX_RX; i++) {
-		INIT_LIST_HEAD(&tp->rx_info[i].list);
-		ret = r8152_submit_rx(tp, &tp->rx_info[i], GFP_KERNEL);
-		if (ret)
-			break;
+	INIT_LIST_HEAD(&tp->rx_used);
+
+	list_splice_init(&tp->rx_info, &tmp_list);
+
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
+
+	list_for_each_entry_safe(agg, agg_next, &tmp_list, info_list) {
+		INIT_LIST_HEAD(&agg->list);
+
+		/* Only RTL8152_MAX_RX rx_agg need to be submitted. */
+		if (++i > RTL8152_MAX_RX) {
+			spin_lock_irqsave(&tp->rx_lock, flags);
+			list_add_tail(&agg->list, &tp->rx_used);
+			spin_unlock_irqrestore(&tp->rx_lock, flags);
+		} else if (unlikely(ret < 0)) {
+			spin_lock_irqsave(&tp->rx_lock, flags);
+			list_add_tail(&agg->list, &tp->rx_done);
+			spin_unlock_irqrestore(&tp->rx_lock, flags);
+		} else {
+			ret = r8152_submit_rx(tp, agg, GFP_KERNEL);
+		}
 	}
 
-	if (ret && ++i < RTL8152_MAX_RX) {
-		struct list_head rx_queue;
-		unsigned long flags;
-
-		INIT_LIST_HEAD(&rx_queue);
-
-		do {
-			struct rx_agg *agg = &tp->rx_info[i++];
-			struct urb *urb = agg->urb;
-
-			urb->actual_length = 0;
-			list_add_tail(&agg->list, &rx_queue);
-		} while (i < RTL8152_MAX_RX);
-
-		spin_lock_irqsave(&tp->rx_lock, flags);
-		list_splice_tail(&rx_queue, &tp->rx_done);
-		spin_unlock_irqrestore(&tp->rx_lock, flags);
-	}
+	spin_lock_irqsave(&tp->rx_lock, flags);
+	WARN_ON(!list_empty(&tp->rx_info));
+	list_splice(&tmp_list, &tp->rx_info);
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
 
 	return ret;
 }
 
 static int rtl_stop_rx(struct r8152 *tp)
 {
-	int i;
+	struct rx_agg *agg, *agg_next;
+	struct list_head tmp_list;
+	unsigned long flags;
 
-	for (i = 0; i < RTL8152_MAX_RX; i++)
-		usb_kill_urb(tp->rx_info[i].urb);
+	INIT_LIST_HEAD(&tmp_list);
+
+	/* The usb_kill_urb() couldn't be used in atomic.
+	 * Therefore, move the list of rx_info to a tmp one.
+	 * Then, list_for_each_entry_safe could be used without
+	 * spin lock.
+	 */
+
+	spin_lock_irqsave(&tp->rx_lock, flags);
+	list_splice_init(&tp->rx_info, &tmp_list);
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
+
+	list_for_each_entry_safe(agg, agg_next, &tmp_list, info_list) {
+		/* At least RTL8152_MAX_RX rx_agg have the page_count being
+		 * equal to 1, so the other ones could be freed safely.
+		 */
+		if (page_count(agg->page) > 1)
+			free_rx_agg(tp, agg);
+		else
+			usb_kill_urb(agg->urb);
+	}
+
+	/* Move back the list of temp to the rx_info */
+	spin_lock_irqsave(&tp->rx_lock, flags);
+	WARN_ON(!list_empty(&tp->rx_info));
+	list_splice(&tmp_list, &tp->rx_info);
+	spin_unlock_irqrestore(&tp->rx_lock, flags);
 
 	while (!skb_queue_empty(&tp->rx_queue))
 		dev_kfree_skb(__skb_dequeue(&tp->rx_queue));
@@ -2580,7 +3213,6 @@ static int rtl_enable(struct r8152 *tp)
 	switch (tp->version) {
 	case RTL_VER_08:
 	case RTL_VER_09:
-	case RTL_TEST_01:
 		r8153b_rx_agg_chg_indicate(tp);
 		break;
 	default:
@@ -2627,9 +3259,10 @@ static void r8153_set_rx_early_timeout(struct r8152 *tp)
 			       ocp_data);
 		break;
 
-	case RTL_TEST_01:
 	case RTL_VER_10:
 	case RTL_VER_11:
+	case RTL_VER_12:
+	case RTL_VER_13:
 		ocp_write_word(tp, MCU_TYPE_USB, USB_RX_EARLY_TIMEOUT,
 			       640 / 8);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_RX_EXTRA_AGGR_TMR,
@@ -2656,9 +3289,14 @@ static void r8153_set_rx_early_size(struct r8152 *tp)
 		break;
 	case RTL_VER_08:
 	case RTL_VER_09:
+		ocp_write_word(tp, MCU_TYPE_USB, USB_RX_EARLY_SIZE,
+			       ocp_data / 8);
+		break;
 	case RTL_TEST_01:
 	case RTL_VER_10:
 	case RTL_VER_11:
+	case RTL_VER_12:
+	case RTL_VER_13:
 		ocp_write_word(tp, MCU_TYPE_USB, USB_RX_EARLY_SIZE,
 			       ocp_data / 8);
 		r8153b_rx_agg_chg_indicate(tp);
@@ -2702,12 +3340,12 @@ static int rtl8153_enable(struct r8152 *tp)
 	}
 
 	if (tp->version == RTL_VER_09) {
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4e8);
-		ocp_data &= ~BIT(1);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd4e8, ocp_data);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_TASK);
+		ocp_data &= ~FC_PATCH_TASK;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_TASK, ocp_data);
 		usleep_range(1000, 2000);
-		ocp_data |= BIT(1);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd4e8, ocp_data);
+		ocp_data |= FC_PATCH_TASK;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_TASK, ocp_data);
 	}
 
 	return rtl_enable(tp);
@@ -2749,51 +3387,7 @@ static void rtl_disable(struct r8152 *tp)
 
 	rtl_stop_rx(tp);
 
-	switch (tp->version) {
-	case RTL_VER_01:
-	case RTL_VER_02:
-	case RTL_VER_03:
-	case RTL_VER_04:
-	case RTL_VER_05:
-	case RTL_VER_06:
-	case RTL_VER_07:
-	case RTL_VER_08:
-	case RTL_VER_09:
-		rtl8152_nic_reset(tp);
-		break;
-
-	case RTL_TEST_01:
-	case RTL_VER_10:
-	case RTL_VER_11:
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CR);
-		ocp_data &= ~CR_TE;
-		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, ocp_data);
-
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4b0);
-		ocp_data &= ~BIT(0);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd4b0, ocp_data);
-
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd406);
-		ocp_data |= BIT(3);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd406, ocp_data);
-
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CR);
-		ocp_data &= ~CR_RE;
-		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, ocp_data);
-
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4b0);
-		ocp_data |= BIT(0);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd4b0, ocp_data);
-
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd406);
-		ocp_data &= ~BIT(3);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd406, ocp_data);
-		break;
-
-	default:
-		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, 0);
-		break;
-	}
+	rtl8152_nic_reset(tp);
 }
 
 static void r8152_power_cut_en(struct r8152 *tp, bool enable)
@@ -2837,13 +3431,15 @@ static void rtl_rx_vlan_en(struct r8152 *tp, bool enable)
 	case RTL_TEST_01:
 	case RTL_VER_10:
 	case RTL_VER_11:
+	case RTL_VER_12:
+	case RTL_VER_13:
 	default:
 		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xc012);
 		if (enable)
 			ocp_data |= BIT(7) | BIT(6);
 		else
 			ocp_data &= ~(BIT(7) | BIT(6));
-		ocp_write_word(tp, MCU_TYPE_PLA, PLA_CPCR, ocp_data);
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xc012, ocp_data);
 		break;
 	}
 }
@@ -3023,6 +3619,19 @@ static void r8156_mac_clk_spd(struct r8152 *tp, bool enable)
 	}
 }
 
+static void r8156b_mac_clk_spd(struct r8152 *tp, bool enable)
+{
+	r8156_mac_clk_spd(tp, enable);
+
+	if (enable) {
+		u32 ocp_data;
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4);
+		ocp_data |= BIT(6);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4, ocp_data);
+	}
+}
+
 static void r8153_u1u2en(struct r8152 *tp, bool enable)
 {
 	u8 u1u2[8];
@@ -3099,31 +3708,31 @@ static void r8153b_ups_flags(struct r8152 *tp)
 
 	switch (tp->ups_info.speed_duplex) {
 	case NWAY_10M_HALF:
-		ups_flags |= 1 << 16;
+		ups_flags |= ups_flags_speed(1);
 		break;
 	case NWAY_10M_FULL:
-		ups_flags |= 2 << 16;
+		ups_flags |= ups_flags_speed(2);
 		break;
 	case NWAY_100M_HALF:
-		ups_flags |= 3 << 16;
+		ups_flags |= ups_flags_speed(3);
 		break;
 	case NWAY_100M_FULL:
-		ups_flags |= 4 << 16;
+		ups_flags |= ups_flags_speed(4);
 		break;
 	case NWAY_1000M_FULL:
-		ups_flags |= 5 << 16;
+		ups_flags |= ups_flags_speed(5);
 		break;
 	case FORCE_10M_HALF:
-		ups_flags |= 6 << 16;
+		ups_flags |= ups_flags_speed(6);
 		break;
 	case FORCE_10M_FULL:
-		ups_flags |= 7 << 16;
+		ups_flags |= ups_flags_speed(7);
 		break;
 	case FORCE_100M_HALF:
-		ups_flags |= 8 << 16;
+		ups_flags |= ups_flags_speed(8);
 		break;
 	case FORCE_100M_FULL:
-		ups_flags |= 9 << 16;
+		ups_flags |= ups_flags_speed(9);
 		break;
 	default:
 		break;
@@ -3165,34 +3774,34 @@ static void r8156_ups_flags(struct r8152 *tp)
 
 	switch (tp->ups_info.speed_duplex) {
 	case FORCE_10M_HALF:
-		ups_flags |= 0 << 16;
+		ups_flags |= ups_flags_speed(0);
 		break;
 	case FORCE_10M_FULL:
-		ups_flags |= 1 << 16;
+		ups_flags |= ups_flags_speed(1);
 		break;
 	case FORCE_100M_HALF:
-		ups_flags |= 2 << 16;
+		ups_flags |= ups_flags_speed(2);
 		break;
 	case FORCE_100M_FULL:
-		ups_flags |= 3 << 16;
+		ups_flags |= ups_flags_speed(3);
 		break;
 	case NWAY_10M_HALF:
-		ups_flags |= 4 << 16;
+		ups_flags |= ups_flags_speed(4);
 		break;
 	case NWAY_10M_FULL:
-		ups_flags |= 5 << 16;
+		ups_flags |= ups_flags_speed(5);
 		break;
 	case NWAY_100M_HALF:
-		ups_flags |= 6 << 16;
+		ups_flags |= ups_flags_speed(6);
 		break;
 	case NWAY_100M_FULL:
-		ups_flags |= 7 << 16;
+		ups_flags |= ups_flags_speed(7);
 		break;
 	case NWAY_1000M_FULL:
-		ups_flags |= 8 << 16;
+		ups_flags |= ups_flags_speed(8);
 		break;
 	case NWAY_2500M_FULL:
-		ups_flags |= 9 << 16;
+		ups_flags |= ups_flags_speed(9);
 		break;
 	default:
 		break;
@@ -3214,10 +3823,23 @@ static void r8156_ups_flags(struct r8152 *tp)
 	ocp_write_dword(tp, MCU_TYPE_USB, USB_UPS_FLAGS, ups_flags);
 }
 
-static void r8153b_green_en(struct r8152 *tp, bool enable)
+static void rtl_green_en(struct r8152 *tp, bool enable)
 {
 	u16 data;
 
+	data = sram_read(tp, SRAM_GREEN_CFG);
+	if (enable)
+		data |= GREEN_ETH_EN;
+	else
+		data &= ~GREEN_ETH_EN;
+	sram_write(tp, SRAM_GREEN_CFG, data);
+
+
+	tp->ups_info.green = enable;
+}
+
+static void r8153b_green_en(struct r8152 *tp, bool enable)
+{
 	if (enable) {
 		sram_write(tp, 0x8045, 0);	/* 10M abiq&ldvbias */
 		sram_write(tp, 0x804d, 0x1222);	/* 100M short abiq&ldvbias */
@@ -3228,11 +3850,7 @@ static void r8153b_green_en(struct r8152 *tp, bool enable)
 		sram_write(tp, 0x805d, 0x2444);	/* 1000M short abiq&ldvbias */
 	}
 
-	data = sram_read(tp, SRAM_GREEN_CFG);
-	data |= GREEN_ETH_EN;
-	sram_write(tp, SRAM_GREEN_CFG, data);
-
-	tp->ups_info.green = enable;
+	rtl_green_en(tp, enable);
 }
 
 static u16 r8153_phy_status(struct r8152 *tp, u16 desired)
@@ -3306,7 +3924,7 @@ static void r8153b_ups_en(struct r8152 *tp, bool enable)
 			r8152_mdio_write(tp, MII_BMCR, data);
 
 			data = r8153_phy_status(tp, PHY_STAT_LAN_ON);
-
+			/* fall through */
 		default:
 			if (data != PHY_STAT_LAN_ON)
 				netif_warn(tp, link, tp->netdev,
@@ -3347,9 +3965,12 @@ static void r8156_ups_en(struct r8152 *tp, bool enable)
 //		ocp_data &= ~(BIT(8) | BIT(9));
 //		ocp_write_word(tp, MCU_TYPE_USB, 0xd32a, ocp_data);
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_MISC_0);
-		if (ocp_data & PCUT_STATUS)
+		if (ocp_read_word(tp, MCU_TYPE_USB, USB_MISC_0) & PCUT_STATUS) {
 			tp->rtl_ops.hw_phy_cfg(tp);
+
+			rtl8152_set_speed(tp, tp->autoneg, tp->speed,
+					  tp->duplex, tp->advertising);
+		}
 	}
 }
 
@@ -3389,20 +4010,20 @@ static void r8153_queue_wake(struct r8152 *tp, bool enable)
 {
 	u32 ocp_data;
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xd38c);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_INDICATE_FALG);
 	if (enable)
-		ocp_data |= BIT(0);
+		ocp_data |= UPCOMING_RUNTIME_D3;
 	else
-		ocp_data &= ~BIT(0);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xd38c, ocp_data);
+		ocp_data &= ~UPCOMING_RUNTIME_D3;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_INDICATE_FALG, ocp_data);
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xd38a);
-	ocp_data &= ~BIT(0);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xd38a, ocp_data);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_SUSPEND_FLAG);
+	ocp_data &= ~LINK_CHG_EVENT;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_SUSPEND_FLAG, ocp_data);
 
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xd398);
-	ocp_data &= ~BIT(8);
-	ocp_write_word(tp, MCU_TYPE_PLA, 0xd398, ocp_data);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS);
+	ocp_data &= ~LINK_CHANGE_FLAG;
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS, ocp_data);
 }
 
 static bool rtl_can_wakeup(struct r8152 *tp)
@@ -3484,7 +4105,8 @@ static void rtl8153b_runtime_enable(struct r8152 *tp, bool enable)
 		r8153_queue_wake(tp, false);
 		rtl_runtime_suspend_enable(tp, false);
 //		r8153_u2p3en(tp, true);
-		r8153b_u1u2en(tp, true);
+		if (tp->udev->speed >= USB_SPEED_SUPER)
+			r8153b_u1u2en(tp, true);
 	}
 }
 
@@ -3499,11 +4121,12 @@ static void rtl8156_runtime_enable(struct r8152 *tp, bool enable)
 //		    tp->udev->speed == USB_SPEED_HIGH)
 //			r8156_ups_en(tp, true);
 	} else {
-		r8156_ups_en(tp, false);
+//		r8156_ups_en(tp, false);
 		r8153_queue_wake(tp, false);
 		rtl_runtime_suspend_enable(tp, false);
 		r8153_u2p3en(tp, true);
-		r8153b_u1u2en(tp, true);
+		if (tp->udev->speed >= USB_SPEED_SUPER)
+			r8153b_u1u2en(tp, true);
 	}
 }
 
@@ -3547,6 +4170,8 @@ static void r8153_teredo_off(struct r8152 *tp)
 	case RTL_TEST_01:
 	case RTL_VER_10:
 	case RTL_VER_11:
+	case RTL_VER_12:
+	case RTL_VER_13:
 		/* The bit 0 ~ 7 are relative with teredo settings. They are
 		 * W1C (write 1 to clear), so set all 1 to disable it.
 		 */
@@ -3573,34 +4198,39 @@ static void rtl_reset_bmu(struct r8152 *tp)
 	ocp_write_byte(tp, MCU_TYPE_USB, USB_BMU_RESET, ocp_data);
 }
 
-static void rtl_clear_bp(struct r8152 *tp)
+/* Clear the bp to stop the firmware before loading a new one */
+static void rtl_clear_bp(struct r8152 *tp, u16 type)
 {
-	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_BP_0, 0);
-	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_BP_2, 0);
-	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_BP_4, 0);
-	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_BP_6, 0);
-	ocp_write_dword(tp, MCU_TYPE_USB, USB_BP_0, 0);
-	ocp_write_dword(tp, MCU_TYPE_USB, USB_BP_2, 0);
-	ocp_write_dword(tp, MCU_TYPE_USB, USB_BP_4, 0);
-	ocp_write_dword(tp, MCU_TYPE_USB, USB_BP_6, 0);
-	usleep_range(3000, 6000);
-	ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_BA, 0);
-	ocp_write_word(tp, MCU_TYPE_USB, USB_BP_BA, 0);
-}
+	switch (tp->version) {
+	case RTL_VER_01:
+	case RTL_VER_02:
+	case RTL_VER_07:
+		break;
+	case RTL_VER_03:
+	case RTL_VER_04:
+	case RTL_VER_05:
+	case RTL_VER_06:
+		ocp_write_byte(tp, type, PLA_BP_EN, 0);
+		break;
+	case RTL_VER_08:
+	case RTL_VER_09:
+	default:
+		if (type == MCU_TYPE_USB) {
+			ocp_write_byte(tp, MCU_TYPE_USB, USB_BP2_EN, 0);
 
-static void r8153_clear_bp(struct r8152 *tp)
-{
-	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_BP_EN, 0);
-	ocp_write_byte(tp, MCU_TYPE_USB, USB_BP_EN, 0);
-	rtl_clear_bp(tp);
-}
-
-static void r8153b_clear_bp(struct r8152 *tp, u16 type)
-{
-	if (type == MCU_TYPE_PLA)
-		ocp_write_byte(tp, MCU_TYPE_PLA, PLA_BP_EN, 0);
-	else
-		ocp_write_byte(tp, MCU_TYPE_USB, USB_BP2_EN, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_8, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_9, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_10, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_11, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_12, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_13, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_14, 0);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_15, 0);
+		} else {
+			ocp_write_byte(tp, MCU_TYPE_PLA, PLA_BP_EN, 0);
+		}
+		break;
+	}
 
 	ocp_write_word(tp, type, PLA_BP_0, 0);
 	ocp_write_word(tp, type, PLA_BP_1, 0);
@@ -3611,18 +4241,79 @@ static void r8153b_clear_bp(struct r8152 *tp, u16 type)
 	ocp_write_word(tp, type, PLA_BP_6, 0);
 	ocp_write_word(tp, type, PLA_BP_7, 0);
 
-	if (type == MCU_TYPE_USB) {
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_8, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_9, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_10, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_11, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_12, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_13, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_14, 0);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_15, 0);
-	}
+	/* wait 3 ms to make sure the firmware is stopped */
 	usleep_range(3000, 6000);
 	ocp_write_word(tp, type, PLA_BP_BA, 0);
+}
+
+static int r8153_patch_request(struct r8152 *tp, bool request)
+{
+	u16 data, check;
+	int i;
+
+	data = ocp_reg_read(tp, OCP_PHY_PATCH_CMD);
+	if (request) {
+		data |= PATCH_REQUEST;
+		check = 0;
+	} else {
+		data &= ~PATCH_REQUEST;
+		check = PATCH_READY;
+	}
+	ocp_reg_write(tp, OCP_PHY_PATCH_CMD, data);
+
+	for (i = 0; i < 5000; i++) {
+		usleep_range(1000, 2000);
+		if ((ocp_reg_read(tp, OCP_PHY_PATCH_STAT) & PATCH_READY) ^ check)
+			break;
+	}
+
+	if (request && !(ocp_reg_read(tp, OCP_PHY_PATCH_STAT) & PATCH_READY)) {
+		dev_err(&tp->intf->dev, "patch request fail\n");
+		r8153_patch_request(tp, false);
+		return -ETIME;
+	} else {
+		return 0;
+	}
+}
+
+static void rtl_patch_key_set(struct r8152 *tp, u16 key_addr, u16 patch_key)
+{
+	sram_write(tp, key_addr, patch_key);
+	sram_write(tp, SRAM_PHY_LOCK, PHY_PATCH_LOCK);
+}
+
+static void rtl_patch_key_clear(struct r8152 *tp, u16 key_addr)
+{
+	u16 data;
+
+	sram_write(tp, 0x0000, 0x0000);
+
+	data = ocp_reg_read(tp, OCP_PHY_LOCK);
+	data &= ~PATCH_LOCK;
+	ocp_reg_write(tp, OCP_PHY_LOCK, data);
+
+	sram_write(tp, key_addr, 0x0000);
+}
+
+static int r8153_pre_ram_code(struct r8152 *tp, u16 key_addr, u16 patch_key)
+{
+	if (r8153_patch_request(tp, true))
+		return -ETIME;
+
+	rtl_patch_key_set(tp, key_addr, patch_key);
+
+	return 0;
+}
+
+static int r8153_post_ram_code(struct r8152 *tp, u16 key_addr)
+{
+	rtl_patch_key_clear(tp, key_addr);
+
+	r8153_patch_request(tp, false);
+
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_OCP_GPHY_BASE, tp->ocp_base);
+
+	return 0;
 }
 
 static void patch4(struct r8152 *tp)
@@ -4023,7 +4714,7 @@ static void r8152b_firmware(struct r8152 *tp)
 			0xbcf1, 0x3001 };
 
 		patch4(tp);
-		rtl_clear_bp(tp);
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
 
 		generic_ocp_write(tp, 0xf800, 0x3f, sizeof(pla_patch_a),
 				  pla_patch_a, MCU_TYPE_PLA);
@@ -4213,8 +4904,82 @@ static void r8152b_firmware(struct r8152 *tp)
 			0x00, 0x00, 0x02, 0xc6,
 			0x00, 0xbe, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00 };
+		static u8 usb_patch_a2[] = {
+			0x10, 0xe0, 0x2d, 0xe0,
+			0x0e, 0xe0, 0x0d, 0xe0,
+			0x0c, 0xe0, 0x0b, 0xe0,
+			0x0a, 0xe0, 0x09, 0xe0,
+			0x08, 0xe0, 0x07, 0xe0,
+			0x06, 0xe0, 0x05, 0xe0,
+			0x04, 0xe0, 0x03, 0xe0,
+			0x02, 0xe0, 0x01, 0xe0,
+			0x1c, 0xc2, 0x40, 0x71,
+			0x9f, 0x48, 0x40, 0x99,
+			0x1f, 0x48, 0x40, 0x99,
+			0x15, 0xc2, 0x40, 0x61,
+			0x90, 0x49, 0x0a, 0xf0,
+			0x42, 0x70, 0x80, 0x49,
+			0x07, 0xf0, 0x80, 0x48,
+			0x42, 0x98, 0x0b, 0xc2,
+			0x40, 0x60, 0x03, 0x48,
+			0x40, 0x88, 0x0a, 0xc2,
+			0x08, 0x18, 0x55, 0x60,
+			0x55, 0x88, 0x02, 0xc0,
+			0x00, 0xb8, 0xc2, 0x09,
+			0x28, 0xd4, 0xd4, 0xc4,
+			0x06, 0xd4, 0x00, 0xb0,
+			0x61, 0xc7, 0x5a, 0xc6,
+			0xe4, 0x9e, 0x0f, 0x1e,
+			0xe6, 0x8e, 0xe6, 0x76,
+			0xef, 0x49, 0xfe, 0xf1,
+			0xe0, 0x73, 0xe2, 0x74,
+			0xb8, 0x26, 0xb8, 0x21,
+			0xb8, 0x25, 0x48, 0x23,
+			0x68, 0x27, 0x04, 0xb4,
+			0x05, 0xb4, 0x06, 0xb4,
+			0x4a, 0xc6, 0xe3, 0x23,
+			0xfe, 0x39, 0x00, 0x1c,
+			0x00, 0x1d, 0x00, 0x13,
+			0x0a, 0xf0, 0xb0, 0x49,
+			0x04, 0xf1, 0x01, 0x05,
+			0xb1, 0x25, 0xfa, 0xe7,
+			0xb8, 0x33, 0x35, 0x43,
+			0x30, 0x31, 0xf6, 0xe7,
+			0x06, 0xb0, 0x05, 0xb0,
+			0xae, 0x41, 0x25, 0x31,
+			0x37, 0xc5, 0x6c, 0x41,
+			0x04, 0xb0, 0x48, 0x26,
+			0x05, 0xb4, 0x36, 0xc7,
+			0x2f, 0xc6, 0x04, 0x06,
+			0xe4, 0x9e, 0x0f, 0x1e,
+			0xe6, 0x8e, 0xe6, 0x76,
+			0xef, 0x49, 0xfe, 0xf1,
+			0xe0, 0x76, 0xe8, 0x25,
+			0xe8, 0x23, 0xf8, 0x27,
+			0x24, 0xc5, 0x6c, 0x41,
+			0x33, 0x22, 0x23, 0x39,
+			0x7c, 0x41, 0xfd, 0x31,
+			0x1f, 0xc6, 0x7e, 0x41,
+			0x20, 0xc6, 0xc4, 0x9f,
+			0xf2, 0x21, 0xdf, 0x30,
+			0xdf, 0x30, 0x05, 0xb0,
+			0xc2, 0x9d, 0x53, 0x22,
+			0x25, 0x31, 0xa3, 0x31,
+			0x12, 0xc7, 0xb7, 0x31,
+			0x12, 0xc7, 0x77, 0x41,
+			0x12, 0xc7, 0xe6, 0x9e,
+			0x0f, 0xc3, 0xde, 0x30,
+			0x60, 0x64, 0xe8, 0x8c,
+			0x06, 0xc7, 0x04, 0x1e,
+			0xe0, 0x8e, 0x02, 0xc4,
+			0x00, 0xbc, 0xb6, 0x02,
+			0x34, 0xe4, 0x00, 0xc0,
+			0x25, 0x00, 0xff, 0x00,
+			0x7f, 0x00, 0x00, 0xf8,
+			0xf0, 0xc4, 0x08, 0xdc };
+		u32 ocp_data;
 
-		rtl_clear_bp(tp);
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
 
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch_a2),
 				  pla_patch_a2, MCU_TYPE_PLA);
@@ -4225,6 +4990,34 @@ static void r8152b_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc2a, 0x13ad);
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc2c, 0x184d);
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc2e, 0x01e1);
+
+		rtl_clear_bp(tp, MCU_TYPE_USB);
+
+		generic_ocp_write(tp, 0xf800, 0xff, sizeof(usb_patch_a2),
+				  usb_patch_a2, MCU_TYPE_USB);
+
+		ocp_write_word(tp, MCU_TYPE_USB, 0xfc26, 0xA000);
+
+		ocp_write_word(tp, MCU_TYPE_USB, 0xfc28, 0x0c87);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2a, 0x024f);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2c, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2e, 0x0000);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd428);
+		ocp_data |= BIT(15);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd428, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xc4d4);
+		ocp_data |= BIT(0);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xc4d4, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xc4d6);
+		ocp_data &= ~BIT(0);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xc4d6, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd428);
+		ocp_data &= ~BIT(15);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd428, ocp_data);
 	}
 }
 
@@ -4298,10 +5091,90 @@ static void r8152_eee_en(struct r8152 *tp, bool enable)
 	ocp_reg_write(tp, OCP_EEE_CONFIG3, config3);
 }
 
-static void r8152b_enable_eee(struct r8152 *tp)
+static void r8153_eee_en(struct r8152 *tp, bool enable)
 {
-	r8152_eee_en(tp, true);
-	r8152_mmd_write(tp, MDIO_MMD_AN, MDIO_AN_EEE_ADV, tp->eee_adv);
+	u32 ocp_data;
+	u16 config;
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EEE_CR);
+	config = ocp_reg_read(tp, OCP_EEE_CFG);
+
+	if (enable) {
+		ocp_data |= EEE_RX_EN | EEE_TX_EN;
+		config |= EEE10_EN;
+	} else {
+		ocp_data &= ~(EEE_RX_EN | EEE_TX_EN);
+		config &= ~EEE10_EN;
+	}
+
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_EEE_CR, ocp_data);
+
+	if (tp->version != RTL_VER_13)
+		ocp_reg_write(tp, OCP_EEE_CFG, config);
+
+	tp->ups_info.eee = enable;
+}
+
+static void r8156_eee_en(struct r8152 *tp, bool enable)
+{
+	u16 config;
+
+	r8153_eee_en(tp, enable);
+
+	config = ocp_reg_read(tp, 0xa6d4);
+
+	if (enable)
+		config |= BIT(0);
+	else
+		config &= ~BIT(0);
+
+	ocp_reg_write(tp, 0xa6d4, config);
+}
+
+static void rtl_eee_enable(struct r8152 *tp, bool enable)
+{
+	switch (tp->version) {
+	case RTL_VER_01:
+	case RTL_VER_02:
+	case RTL_VER_07:
+		if (enable) {
+			r8152_eee_en(tp, true);
+			r8152_mmd_write(tp, MDIO_MMD_AN, MDIO_AN_EEE_ADV,
+					tp->eee_adv);
+		} else {
+			r8152_eee_en(tp, false);
+			r8152_mmd_write(tp, MDIO_MMD_AN, MDIO_AN_EEE_ADV, 0);
+		}
+		break;
+	case RTL_VER_03:
+	case RTL_VER_04:
+	case RTL_VER_05:
+	case RTL_VER_06:
+	case RTL_VER_08:
+	case RTL_VER_09:
+		if (enable) {
+			r8153_eee_en(tp, true);
+			ocp_reg_write(tp, OCP_EEE_ADV, tp->eee_adv);
+		} else {
+			r8153_eee_en(tp, false);
+			ocp_reg_write(tp, OCP_EEE_ADV, 0);
+		}
+		break;
+	case RTL_VER_10:
+	case RTL_VER_11:
+	case RTL_VER_12:
+	case RTL_VER_13:
+		if (enable) {
+			r8156_eee_en(tp, true);
+			ocp_reg_write(tp, OCP_EEE_ADV, tp->eee_adv);
+		} else {
+			r8156_eee_en(tp, false);
+			ocp_reg_write(tp, OCP_EEE_ADV, 0);
+		}
+		break;
+	default:
+		break;
+	}
 }
 
 static void r8152b_enable_fc(struct r8152 *tp)
@@ -4326,17 +5199,29 @@ static void r8152b_hw_phy_cfg(struct r8152 *tp)
 {
 	r8152b_firmware(tp);
 
-	r8152b_enable_eee(tp);
+	rtl_eee_enable(tp, tp->eee_en);
 	r8152_aldps_en(tp, true);
 	r8152b_enable_fc(tp);
 
 	set_bit(PHY_RESET, &tp->flags);
 }
 
-static void r8152b_exit_oob(struct r8152 *tp)
+static void wait_oob_link_list_ready(struct r8152 *tp)
 {
 	u32 ocp_data;
 	int i;
+
+	for (i = 0; i < 1000; i++) {
+		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
+		if (ocp_data & LINK_LIST_READY)
+			break;
+		usleep_range(1000, 2000);
+	}
+}
+
+static void r8152b_exit_oob(struct r8152 *tp)
+{
+	u32 ocp_data;
 
 	ocp_data = ocp_read_dword(tp, MCU_TYPE_PLA, PLA_RCR);
 	ocp_data &= ~RCR_ACPT_ALL;
@@ -4355,23 +5240,13 @@ static void r8152b_exit_oob(struct r8152 *tp)
 	ocp_data &= ~MCU_BORW_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7);
 	ocp_data |= RE_INIT_LL;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	rtl8152_nic_reset(tp);
 
@@ -4394,7 +5269,7 @@ static void r8152b_exit_oob(struct r8152 *tp)
 	}
 
 	/* TX share fifo free credit full threshold */
-	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_TXFIFO_CTRL, TXFIFO_THR_NORMAL);
+	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_TXFIFO_CTRL, TXFIFO_THR_NORMAL2);
 
 	ocp_write_byte(tp, MCU_TYPE_USB, USB_TX_AGG, TX_AGG_MAX_THRESHOLD);
 	ocp_write_dword(tp, MCU_TYPE_USB, USB_RX_BUF_TH, RX_THR_HIGH);
@@ -4413,7 +5288,6 @@ static void r8152b_exit_oob(struct r8152 *tp)
 static void r8152b_enter_oob(struct r8152 *tp)
 {
 	u32 ocp_data;
-	int i;
 
 	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
 	ocp_data &= ~NOW_IS_OOB;
@@ -4425,31 +5299,21 @@ static void r8152b_enter_oob(struct r8152 *tp)
 
 	rtl_disable(tp);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7);
 	ocp_data |= RE_INIT_LL;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RMS, RTL8152_RMS);
 
 	rtl_rx_vlan_en(tp, true);
 
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PAL_BDC_CR);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_BDC_CR);
 	ocp_data |= ALDPS_PROXY_MODE;
-	ocp_write_word(tp, MCU_TYPE_PLA, PAL_BDC_CR, ocp_data);
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_BDC_CR, ocp_data);
 
 	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
 	ocp_data |= NOW_IS_OOB | DIS_MCU_CLROOB;
@@ -4460,66 +5324,6 @@ static void r8152b_enter_oob(struct r8152 *tp)
 	ocp_data = ocp_read_dword(tp, MCU_TYPE_PLA, PLA_RCR);
 	ocp_data |= RCR_APM | RCR_AM | RCR_AB;
 	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_RCR, ocp_data);
-}
-
-static int r8153_patch_request(struct r8152 *tp, bool request)
-{
-	u16 data, check;
-	int i;
-
-	data = ocp_reg_read(tp, OCP_PHY_PATCH_CMD);
-	if (request) {
-		data |= PATCH_REQUEST;
-		check = 0;
-	} else {
-		data &= ~PATCH_REQUEST;
-		check = PATCH_READY;
-	}
-	ocp_reg_write(tp, OCP_PHY_PATCH_CMD, data);
-
-	for (i = 0; i < 5000; i++) {
-		usleep_range(1000, 2000);
-		if ((ocp_reg_read(tp, OCP_PHY_PATCH_STAT) & PATCH_READY) ^ check)
-			break;
-	}
-
-	if (request && !(ocp_reg_read(tp, OCP_PHY_PATCH_STAT) & PATCH_READY)) {
-		netif_err(tp, drv, tp->netdev, "patch request fail\n");
-		r8153_patch_request(tp, false);
-		return -ETIME;
-	} else {
-		return 0;
-	}
-}
-
-static int r8153_pre_ram_code(struct r8152 *tp, u16 key_addr, u16 patch_key)
-{
-	if (r8153_patch_request(tp, true))
-		return -ETIME;
-
-	sram_write(tp, key_addr, patch_key);
-	sram_write(tp, 0xb82e, 0x0001);
-
-	return 0;
-}
-
-static int r8153_post_ram_code(struct r8152 *tp, u16 key_addr)
-{
-	u16 data;
-
-	sram_write(tp, 0x0000, 0x0000);
-
-	data = ocp_reg_read(tp, 0xb82e);
-	data &= ~0x0001;
-	ocp_reg_write(tp, 0xb82e, data);
-
-	sram_write(tp, key_addr, 0x0000);
-
-	r8153_patch_request(tp, false);
-
-	ocp_write_word(tp, MCU_TYPE_PLA, PLA_OCP_GPHY_BASE, tp->ocp_base);
-
-	return 0;
 }
 
 static int r8156_lock_mian(struct r8152 *tp, bool lock)
@@ -4560,8 +5364,11 @@ static void r8153_wdt1_end(struct r8152 *tp)
 {
 	int i;
 
+	/* Wait till the WTD timer is ready. It would take at most 104 ms. */
 	for (i = 0; i < 104; i++) {
-		if (!(ocp_read_byte(tp, MCU_TYPE_USB, 0xe404) & 1))
+		u32 ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, USB_WDT1_CTRL);
+
+		if (!(ocp_data & WTD1_EN))
 			break;
 		usleep_range(1000, 2000);
 	}
@@ -4570,8 +5377,6 @@ static void r8153_wdt1_end(struct r8152 *tp)
 static void r8153_firmware(struct r8152 *tp)
 {
 	if (tp->version == RTL_VER_03) {
-		r8153_clear_bp(tp);
-
 		r8153_pre_ram_code(tp, 0x8146, 0x7000);
 		sram_write(tp, 0xb820, 0x0290);
 		sram_write(tp, 0xa012, 0x0000);
@@ -5025,9 +5830,9 @@ static void r8153_firmware(struct r8152 *tp)
 		r8153_post_ram_code(tp, 0x8146);
 
 		r8153_wdt1_end(tp);
-		r8153_clear_bp(tp);
 
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x0000);
+		rtl_clear_bp(tp, MCU_TYPE_USB);
+
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(usb_patch_b),
 				  usb_patch_b, MCU_TYPE_USB);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc26, 0xa000);
@@ -5041,12 +5846,20 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc36, 0x0098);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x00FF);
 
-		if (!(ocp_read_word(tp, MCU_TYPE_PLA, 0xd38e) & BIT(0))) {
-			ocp_write_word(tp, MCU_TYPE_PLA, 0xd38c, 0x0082);
-			ocp_write_word(tp, MCU_TYPE_PLA, 0xd38e, 0x0082);
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
+
+		/* Enable backup/restore of MACDBG. This is required after
+		 * clearing PLA break points and before applying the PLA
+		 * firmware.
+		 */
+		if (!(ocp_read_word(tp, MCU_TYPE_PLA, PLA_MACDBG_POST) &
+		      DEBUG_OE)) {
+			ocp_write_word(tp, MCU_TYPE_PLA, PLA_MACDBG_PRE,
+				       DEBUG_LTSSM);
+			ocp_write_word(tp, MCU_TYPE_PLA, PLA_MACDBG_POST,
+				       DEBUG_LTSSM);
 		}
 
-		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x0000);
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch_b),
 				  pla_patch_b, MCU_TYPE_PLA);
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc26, 0x8000);
@@ -5060,14 +5873,15 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc36, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x007f);
 
-		ocp_write_word(tp, MCU_TYPE_PLA, 0xd388, 0x08ca);
+		/* reset UPHY timer to 36 ms */
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_UPHY_TIMER, 36000 / 16);
 	} else if (tp->version == RTL_VER_05) {
 		u32 ocp_data;
 		static u8 usb_patch_c[] = {
 			0x08, 0xe0, 0x0a, 0xe0,
 			0x14, 0xe0, 0x58, 0xe0,
 			0x64, 0xe0, 0x79, 0xe0,
-			0xa8, 0xe0, 0xb3, 0xe0,
+			0xab, 0xe0, 0xb6, 0xe0,
 			0x02, 0xc5, 0x00, 0xbd,
 			0x38, 0x3b, 0xdb, 0x49,
 			0x04, 0xf1, 0x06, 0xc3,
@@ -5127,41 +5941,43 @@ static void r8153_firmware(struct r8152 *tp)
 			0x02, 0xc1, 0x00, 0xb9,
 			0x9c, 0x15, 0x00, 0xd8,
 			0xef, 0xcf, 0x20, 0xd4,
-			0x2b, 0xc5, 0xa0, 0x77,
-			0x00, 0x1c, 0xa0, 0x9c,
-			0x28, 0xc5, 0xa0, 0x64,
-			0xc0, 0x48, 0xc1, 0x48,
-			0xc2, 0x48, 0xa0, 0x8c,
-			0xb1, 0x64, 0xc0, 0x48,
-			0xb1, 0x8c, 0x20, 0xc5,
-			0xa0, 0x64, 0x40, 0x48,
-			0x41, 0x48, 0xc2, 0x48,
-			0xa0, 0x8c, 0x19, 0xc5,
-			0xa4, 0x64, 0x44, 0x48,
-			0xa4, 0x8c, 0xb1, 0x64,
-			0x40, 0x48, 0xb1, 0x8c,
-			0x14, 0xc4, 0x80, 0x73,
-			0x13, 0xc4, 0x82, 0x9b,
-			0x11, 0x1b, 0x80, 0x9b,
-			0x0c, 0xc5, 0xa0, 0x64,
+			0x30, 0x18, 0xe7, 0xc1,
+			0xcb, 0xef, 0x2b, 0xc5,
+			0xa0, 0x77, 0x00, 0x1c,
+			0xa0, 0x9c, 0x28, 0xc5,
+			0xa0, 0x64, 0xc0, 0x48,
+			0xc1, 0x48, 0xc2, 0x48,
+			0xa0, 0x8c, 0xb1, 0x64,
+			0xc0, 0x48, 0xb1, 0x8c,
+			0x20, 0xc5, 0xa0, 0x64,
 			0x40, 0x48, 0x41, 0x48,
-			0x42, 0x48, 0xa0, 0x8c,
-			0x05, 0xc5, 0xa0, 0x9f,
-			0x02, 0xc5, 0x00, 0xbd,
-			0x6c, 0x3a, 0x1e, 0xfc,
-			0x10, 0xd8, 0x86, 0xd4,
-			0xf8, 0xcb, 0x20, 0xe4,
-			0x0a, 0xc0, 0x16, 0x61,
-			0x91, 0x48, 0x16, 0x89,
-			0x07, 0xc0, 0x11, 0x19,
-			0x0c, 0x89, 0x02, 0xc1,
-			0x00, 0xb9, 0x02, 0x06,
-			0x00, 0xd4, 0x40, 0xb4,
-			0xfe, 0xc0, 0x16, 0x61,
-			0x91, 0x48, 0x16, 0x89,
-			0xfb, 0xc0, 0x11, 0x19,
-			0x0c, 0x89, 0x02, 0xc1,
-			0x00, 0xb9, 0xd2, 0x05 };
+			0xc2, 0x48, 0xa0, 0x8c,
+			0x19, 0xc5, 0xa4, 0x64,
+			0x44, 0x48, 0xa4, 0x8c,
+			0xb1, 0x64, 0x40, 0x48,
+			0xb1, 0x8c, 0x14, 0xc4,
+			0x80, 0x73, 0x13, 0xc4,
+			0x82, 0x9b, 0x11, 0x1b,
+			0x80, 0x9b, 0x0c, 0xc5,
+			0xa0, 0x64, 0x40, 0x48,
+			0x41, 0x48, 0x42, 0x48,
+			0xa0, 0x8c, 0x05, 0xc5,
+			0xa0, 0x9f, 0x02, 0xc5,
+			0x00, 0xbd, 0x6c, 0x3a,
+			0x1e, 0xfc, 0x10, 0xd8,
+			0x86, 0xd4, 0xf8, 0xcb,
+			0x20, 0xe4, 0x0a, 0xc0,
+			0x16, 0x61, 0x91, 0x48,
+			0x16, 0x89, 0x07, 0xc0,
+			0x11, 0x19, 0x0c, 0x89,
+			0x02, 0xc1, 0x00, 0xb9,
+			0x02, 0x06, 0x00, 0xd4,
+			0x40, 0xb4, 0xfe, 0xc0,
+			0x16, 0x61, 0x91, 0x48,
+			0x16, 0x89, 0xfb, 0xc0,
+			0x11, 0x19, 0x0c, 0x89,
+			0x02, 0xc1, 0x00, 0xb9,
+			0xd2, 0x05, 0x00, 0x00 };
 		static u8 pla_patch_c[] = {
 			0x5d, 0xe0, 0x07, 0xe0,
 			0x0f, 0xe0, 0x5a, 0xe0,
@@ -5328,10 +6144,6 @@ static void r8153_firmware(struct r8152 *tp)
 			0x00, 0xd8, 0x02, 0xc6,
 			0x00, 0xbe, 0xe0, 0x08 };
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xcfca);
-		ocp_data &= ~0x4000;
-		ocp_write_word(tp, MCU_TYPE_USB, 0xcfca, ocp_data);
-
 		r8153_pre_ram_code(tp, 0x8146, 0x7001);
 		sram_write(tp, 0xb820, 0x0290);
 		sram_write(tp, 0xa012, 0x0000);
@@ -5359,9 +6171,13 @@ static void r8153_firmware(struct r8152 *tp)
 		r8153_post_ram_code(tp, 0x8146);
 
 		r8153_wdt1_end(tp);
-		r8153_clear_bp(tp);
 
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x0000);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN0);
+		ocp_data &= ~FW_FIX_SUSPEND;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN0, ocp_data);
+
+		rtl_clear_bp(tp, MCU_TYPE_USB);
+
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(usb_patch_c),
 				  usb_patch_c, MCU_TYPE_USB);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc26, 0xa000);
@@ -5369,7 +6185,7 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2a, 0x027c);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2c, 0x15de);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2e, 0x10ce);
-		if (ocp_read_byte(tp, MCU_TYPE_USB, 0xcfef) & 1)
+		if (ocp_read_byte(tp, MCU_TYPE_USB, USB_CSTMR) & FORCE_SUPER)
 			ocp_write_word(tp, MCU_TYPE_USB, 0xfc30, 0x1578);
 		else
 			ocp_write_word(tp, MCU_TYPE_USB, 0xfc30, 0x1adc);
@@ -5378,7 +6194,8 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc36, 0x05c8);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x00ff);
 
-		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x0000);
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
+
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch_c),
 				  pla_patch_c, MCU_TYPE_PLA);
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc26, 0x8000);
@@ -5392,12 +6209,16 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc36, 0x0894);
 		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x00e6);
 
-		ocp_write_word(tp, MCU_TYPE_PLA, 0xd388, 0x08ca);
-		ocp_write_word(tp, MCU_TYPE_PLA, 0xd398, 0x0084);
+		/* reset UPHY timer to 36 ms */
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_UPHY_TIMER, 36000 / 16);
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xcfca);
-		ocp_data |= 0x4000;
-		ocp_write_word(tp, MCU_TYPE_USB, 0xcfca, ocp_data);
+		/* enable U3P3 check, set the counter to 4 */
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS,
+			       U3P3_CHECK_EN | 4);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN0);
+		ocp_data |= FW_FIX_SUSPEND;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN0, ocp_data);
 
 		ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, USB_USB2PHY);
 		ocp_data |= USB2PHY_L1 | USB2PHY_SUSPEND;
@@ -5407,12 +6228,12 @@ static void r8153_firmware(struct r8152 *tp)
 		static u8 usb_patch_d[] = {
 			0x08, 0xe0, 0x0e, 0xe0,
 			0x11, 0xe0, 0x24, 0xe0,
-			0x30, 0xe0, 0x38, 0xe0,
+			0x2b, 0xe0, 0x33, 0xe0,
 			0x3a, 0xe0, 0x3c, 0xe0,
 			0x1e, 0xc3, 0x70, 0x61,
 			0x12, 0x48, 0x70, 0x89,
 			0x02, 0xc3, 0x00, 0xbb,
-			0x02, 0x17, 0x31, 0x19,
+			0x02, 0x17, 0x32, 0x19,
 			0x02, 0xc3, 0x00, 0xbb,
 			0x44, 0x14, 0x30, 0x18,
 			0x11, 0xc1, 0x05, 0xe8,
@@ -5424,22 +6245,22 @@ static void r8153_firmware(struct r8152 *tp)
 			0x8e, 0x49, 0xfe, 0xf1,
 			0x02, 0xb0, 0x80, 0xff,
 			0xc0, 0xd4, 0xe4, 0x40,
-			0x20, 0xd4, 0x0c, 0xc0,
-			0x00, 0x63, 0xb5, 0x49,
-			0x0c, 0xc0, 0x30, 0x18,
-			0x06, 0xc1, 0xed, 0xef,
-			0xf8, 0xc7, 0x02, 0xc0,
+			0x20, 0xd4, 0x30, 0x18,
+			0x06, 0xc1, 0xf1, 0xef,
+			0xfc, 0xc7, 0x02, 0xc0,
 			0x00, 0xb8, 0x38, 0x12,
-			0xe4, 0x4b, 0x00, 0xd8,
-			0x0c, 0x61, 0x95, 0x48,
-			0x96, 0x48, 0x92, 0x48,
-			0x93, 0x48, 0x0c, 0x89,
-			0x02, 0xc0, 0x00, 0xb8,
-			0x0e, 0x06, 0x02, 0xc5,
-			0x00, 0xbd, 0x00, 0x00,
-			0x02, 0xc1, 0x00, 0xb9,
-			0x00, 0x00, 0x02, 0xc1,
-			0x00, 0xb9, 0x00, 0x00 };
+			0xe4, 0x4b, 0x0c, 0x61,
+			0x92, 0x48, 0x93, 0x48,
+			0x95, 0x48, 0x96, 0x48,
+			0x0c, 0x89, 0x02, 0xc0,
+			0x00, 0xb8, 0x0e, 0x06,
+			0x30, 0x18, 0xf5, 0xc1,
+			0xe0, 0xef, 0x04, 0xc5,
+			0x02, 0xc4, 0x00, 0xbc,
+			0x76, 0x3c, 0x1e, 0xfc,
+			0x02, 0xc6, 0x00, 0xbe,
+			0x00, 0x00, 0x02, 0xc6,
+			0x00, 0xbe, 0x00, 0x00 };
 		static u8 pla_patch_d[] = {
 			0x03, 0xe0, 0x16, 0xe0,
 			0x30, 0xe0, 0x12, 0xc2,
@@ -5513,9 +6334,8 @@ static void r8153_firmware(struct r8152 *tp)
 		sram_write(tp, 0xb820, 0x0210);
 		r8153_post_ram_code(tp, 0x8146);
 
-		r8153_clear_bp(tp);
+		rtl_clear_bp(tp, MCU_TYPE_USB);
 
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x0000);
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(usb_patch_d),
 				  usb_patch_d, MCU_TYPE_USB);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc26, 0xa000);
@@ -5524,15 +6344,16 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2c, 0x1792);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc2e, 0x1236);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc30, 0x0606);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xfc32, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xfc32, 0x3C74);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc34, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_USB, 0xfc36, 0x0000);
-		if (ocp_read_byte(tp, MCU_TYPE_USB, 0xcfef) & 1)
-			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x001b);
+		if (ocp_read_byte(tp, MCU_TYPE_USB, USB_CSTMR) & FORCE_SUPER)
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x003f);
 		else
-			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x001a);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_BP_EN, 0x003e);
 
-		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x0000);
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
+
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch_d),
 				  pla_patch_d, MCU_TYPE_PLA);
 		ocp_write_word(tp, MCU_TYPE_PLA, 0xfc26, 0x8000);
@@ -5549,6 +6370,10 @@ static void r8153_firmware(struct r8152 *tp)
 		ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, USB_USB2PHY);
 		ocp_data |= USB2PHY_L1 | USB2PHY_SUSPEND;
 		ocp_write_byte(tp, MCU_TYPE_USB, USB_USB2PHY, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1);
+		ocp_data |= FW_IP_RESET_EN;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1, ocp_data);
 	}
 }
 
@@ -5562,9 +6387,9 @@ static void r8153b_firmware(struct r8152 *tp)
 			0x6c, 0xe0, 0x85, 0xe0,
 			0xa5, 0xe0, 0xbe, 0xe0,
 			0xd8, 0xe0, 0xdb, 0xe0,
-			0xdd, 0xe0, 0xdf, 0xe0,
-			0xe1, 0xe0, 0xe3, 0xe0,
-			0xe5, 0xe0, 0xe7, 0xe0,
+			0xf3, 0xe0, 0xf5, 0xe0,
+			0xf7, 0xe0, 0xf9, 0xe0,
+			0xfb, 0xe0, 0xfd, 0xe0,
 			0x16, 0xc0, 0x00, 0x75,
 			0xd1, 0x49, 0x0d, 0xf0,
 			0x0f, 0xc0, 0x0f, 0xc5,
@@ -5671,8 +6496,19 @@ static void r8153b_firmware(struct r8152 *tp)
 			0x34, 0xd3, 0x00, 0xdc,
 			0x1e, 0x89, 0x02, 0xc0,
 			0x00, 0xb8, 0xfa, 0x12,
-			0x02, 0xc0, 0x00, 0xb8,
-			0x00, 0x00, 0x02, 0xc0,
+			0x18, 0xc0, 0x00, 0x65,
+			0xd1, 0x49, 0x0e, 0xf0,
+			0x11, 0xc0, 0x11, 0xc5,
+			0x00, 0x1e, 0x08, 0x9e,
+			0x0c, 0x9d, 0x0e, 0xc6,
+			0x0a, 0x9e, 0x8f, 0x1c,
+			0x0e, 0x8c, 0x0e, 0x74,
+			0xcf, 0x49, 0xfe, 0xf1,
+			0x04, 0xc0, 0x02, 0xc2,
+			0x00, 0xba, 0xa0, 0x41,
+			0x06, 0xd4, 0x00, 0xdc,
+			0x24, 0xe4, 0x80, 0x02,
+			0x34, 0xd3, 0x02, 0xc0,
 			0x00, 0xb8, 0x00, 0x00,
 			0x02, 0xc0, 0x00, 0xb8,
 			0x00, 0x00, 0x02, 0xc0,
@@ -5757,10 +6593,11 @@ static void r8153b_firmware(struct r8152 *tp)
 			0x02, 0xc2, 0x00, 0xba,
 			0xda, 0x0e, 0x08, 0xe9 };
 
-		r8153b_clear_bp(tp, MCU_TYPE_USB);
-		r8153b_clear_bp(tp, MCU_TYPE_PLA);
+		rtl_clear_bp(tp, MCU_TYPE_USB);
 
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd340, 0x807d);
+		/* enable fc timer and set timer to 1 second. */
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FC_TIMER,
+			       CTRL_TIMER_EN | (1000 / 8));
 
 		generic_ocp_write(tp, 0xe600, 0xff, sizeof(usb_patch2_b),
 				  usb_patch2_b, MCU_TYPE_USB);
@@ -5775,14 +6612,16 @@ static void r8153b_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_6, 0x340c);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_7, 0x335e);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_8, 0x12f8);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_9, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_9, 0x419e);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_10, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_11, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_12, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_13, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_14, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_15, 0x0000);
-		ocp_write_word(tp, MCU_TYPE_USB, USB_BP2_EN, 0x01ff);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP2_EN, 0x03ff);
+
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
 
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch2_b),
 				  pla_patch2_b, MCU_TYPE_PLA);
@@ -5798,23 +6637,23 @@ static void r8153b_firmware(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_7, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x001e);
 
-		if (ocp_read_byte(tp, MCU_TYPE_USB, 0xd81f) & BIT(2)) {
+		if (ocp_read_byte(tp, MCU_TYPE_USB, USB_MISC_1) & BND_MASK) {
 			ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_BP_EN);
 			ocp_data |= BIT(0);
 			ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, ocp_data);
 		}
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd334);
-		ocp_data |= BIT(1);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd334, ocp_data);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_CTRL);
+		ocp_data |= FLOW_CTRL_PATCH_OPT;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_CTRL, ocp_data);
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4e8);
-		ocp_data |= BIT(1);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xd4e8, ocp_data);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_TASK);
+		ocp_data |= FC_PATCH_TASK;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_TASK, ocp_data);
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xcfcc);
-		ocp_data |= BIT(9);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xcfcc, ocp_data);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1);
+		ocp_data |= FW_IP_RESET_EN;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1, ocp_data);
 	}
 }
 
@@ -5961,7 +6800,7 @@ static void r8156_firmware(struct r8152 *tp)
 		data |= BIT(0);
 		ocp_reg_write(tp, 0xb896, data);
 
-		r8153_pre_ram_code(tp, 0x8024, 0x0000);
+		rtl_patch_key_set(tp, 0x8024, 0x0000);
 
 		data = ocp_reg_read(tp, 0xb820);
 		data |= BIT(7);
@@ -7130,7 +7969,7 @@ static void r8156_firmware(struct r8152 *tp)
 		sram_write(tp, 0xb81e, 0xffff);
 		sram_write(tp, 0xb832, 0x0003);
 
-		r8153_post_ram_code(tp, 0x8024);
+		rtl_patch_key_clear(tp, 0x8024);
 		ocp_reg_write(tp, 0xc414, 0x0200);
 
 		r8153_patch_request(tp, false);
@@ -7237,7 +8076,7 @@ static void r8156_firmware(struct r8152 *tp)
 
 		r8156_lock_mian(tp, false);
 
-		r8153b_clear_bp(tp, MCU_TYPE_USB);
+		rtl_clear_bp(tp, MCU_TYPE_USB);
 
 		generic_ocp_write(tp, 0xe600, 0xff, sizeof(usb3_patch_t),
 				  usb3_patch_t, MCU_TYPE_USB);
@@ -7286,44 +8125,6 @@ static void r8153_aldps_en(struct r8152 *tp, bool enable)
 	tp->ups_info.aldps = enable;
 }
 
-static void r8153_eee_en(struct r8152 *tp, bool enable)
-{
-	u32 ocp_data;
-	u16 config;
-
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EEE_CR);
-	config = ocp_reg_read(tp, OCP_EEE_CFG);
-
-	if (enable) {
-		ocp_data |= EEE_RX_EN | EEE_TX_EN;
-		config |= EEE10_EN;
-	} else {
-		ocp_data &= ~(EEE_RX_EN | EEE_TX_EN);
-		config &= ~EEE10_EN;
-	}
-
-	ocp_write_word(tp, MCU_TYPE_PLA, PLA_EEE_CR, ocp_data);
-	ocp_reg_write(tp, OCP_EEE_CFG, config);
-
-	tp->ups_info.eee = enable;
-}
-
-static void r8156_eee_en(struct r8152 *tp, bool enable)
-{
-	u16 config;
-
-	r8153_eee_en(tp, enable);
-
-	config = ocp_reg_read(tp, 0xa6d4);
-
-	if (enable)
-		config |= BIT(0);
-	else
-		config &= ~BIT(0);
-
-	ocp_reg_write(tp, 0xa6d4, config);
-}
-
 static void r8153_hw_phy_cfg(struct r8152 *tp)
 {
 	u32 ocp_data;
@@ -7333,8 +8134,7 @@ static void r8153_hw_phy_cfg(struct r8152 *tp)
 	r8153_aldps_en(tp, false);
 
 	/* disable EEE before updating the PHY parameters */
-	r8153_eee_en(tp, false);
-	ocp_reg_write(tp, OCP_EEE_ADV, 0);
+	rtl_eee_enable(tp, false);
 
 	r8153_firmware(tp);
 
@@ -7367,10 +8167,8 @@ static void r8153_hw_phy_cfg(struct r8152 *tp)
 	sram_write(tp, SRAM_10M_AMP1, 0x00af);
 	sram_write(tp, SRAM_10M_AMP2, 0x0208);
 
-	if (tp->eee_en) {
-		r8153_eee_en(tp, true);
-		ocp_reg_write(tp, OCP_EEE_ADV, tp->eee_adv);
-	}
+	if (tp->eee_en)
+		rtl_eee_enable(tp, true);
 
 	r8153_aldps_en(tp, true);
 	r8152b_enable_fc(tp);
@@ -7410,8 +8208,7 @@ static void r8153b_hw_phy_cfg(struct r8152 *tp)
 	r8153_aldps_en(tp, false);
 
 	/* disable EEE before updating the PHY parameters */
-	r8153_eee_en(tp, false);
-	ocp_reg_write(tp, OCP_EEE_ADV, 0);
+	rtl_eee_enable(tp, false);
 
 	/* U1/U2/L1 idle timer. 500 us */
 	ocp_write_word(tp, MCU_TYPE_USB, USB_U1U2_TIMER, 500);
@@ -7484,10 +8281,8 @@ static void r8153b_hw_phy_cfg(struct r8152 *tp)
 		r8153_patch_request(tp, false);
 	}
 
-	if (tp->eee_en) {
-		r8153_eee_en(tp, true);
-		ocp_reg_write(tp, OCP_EEE_ADV, tp->eee_adv);
-	}
+	if (tp->eee_en)
+		rtl_eee_enable(tp, true);
 
 	r8153_aldps_en(tp, true);
 	r8152b_enable_fc(tp);
@@ -7499,7 +8294,6 @@ static void r8153b_hw_phy_cfg(struct r8152 *tp)
 static void r8153_first_init(struct r8152 *tp)
 {
 	u32 ocp_data;
-	int i;
 
 	rxdy_gated_en(tp, true);
 	r8153_teredo_off(tp);
@@ -7519,23 +8313,13 @@ static void r8153_first_init(struct r8152 *tp)
 	ocp_data &= ~MCU_BORW_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7);
 	ocp_data |= RE_INIT_LL;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	rtl_rx_vlan_en(tp, tp->netdev->features & NETIF_F_HW_VLAN_CTAG_RX);
 
@@ -7560,7 +8344,6 @@ static void r8153_first_init(struct r8152 *tp)
 static void r8153_enter_oob(struct r8152 *tp)
 {
 	u32 ocp_data;
-	int i;
 
 	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
 	ocp_data &= ~NOW_IS_OOB;
@@ -7569,23 +8352,13 @@ static void r8153_enter_oob(struct r8152 *tp)
 	rtl_disable(tp);
 	rtl_reset_bmu(tp);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7);
 	ocp_data |= RE_INIT_LL;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_SFF_STS_7, ocp_data);
 
-	for (i = 0; i < 1000; i++) {
-		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
-		if (ocp_data & LINK_LIST_READY)
-			break;
-		usleep_range(1000, 2000);
-	}
+	wait_oob_link_list_ready(tp);
 
 	ocp_data = tp->netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RMS, ocp_data);
@@ -7615,9 +8388,9 @@ static void r8153_enter_oob(struct r8152 *tp)
 
 	rtl_rx_vlan_en(tp, true);
 
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PAL_BDC_CR);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_BDC_CR);
 	ocp_data |= ALDPS_PROXY_MODE;
-	ocp_write_word(tp, MCU_TYPE_PLA, PAL_BDC_CR, ocp_data);
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_BDC_CR, ocp_data);
 
 	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
 	ocp_data |= NOW_IS_OOB | DIS_MCU_CLROOB;
@@ -7701,6 +8474,68 @@ static int rtl8156_enable(struct r8152 *tp)
 	return rtl_enable(tp);
 }
 
+static int rtl8156b_enable(struct r8152 *tp)
+{
+	u32 ocp_data;
+	u16 speed;
+
+	if (test_bit(RTL8152_UNPLUG, &tp->flags))
+		return -ENODEV;
+
+	set_tx_qlen(tp);
+	rtl_set_eee_plus(tp);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4ee);
+	ocp_data &= ~0x1ff;
+	ocp_data |= 2;
+	ocp_write_word(tp, MCU_TYPE_USB, 0xd4ee, ocp_data);
+
+	r8153_set_rx_early_timeout(tp);
+	r8153_set_rx_early_size(tp);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_TCR1);
+	ocp_data &= ~(BIT(3) | BIT(9) | BIT(8));
+	speed = rtl8152_get_speed(tp);
+	if ((speed & (_10bps | _100bps)) && !(speed & FULL_DUP)) {
+		ocp_data |= BIT(9);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_TCR1, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4);
+		ocp_data &= ~TX10MIDLE_EN;
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4, ocp_data);
+	} else {
+		ocp_data |= BIT(9) | BIT(8);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_TCR1, ocp_data);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4);
+		ocp_data |= TX10MIDLE_EN;
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4, ocp_data);
+	}
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4);
+	if (speed & _2500bps)
+		ocp_data &= ~BIT(6);
+	else
+		ocp_data |= BIT(6);
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4, ocp_data);
+
+	if (tp->udev->speed == USB_SPEED_HIGH) {
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xb45e);
+		ocp_data &= ~0xf;
+		ocp_data |= 1;
+		ocp_write_word(tp, MCU_TYPE_USB, 0xb45e, ocp_data);
+	}
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_TASK);
+	ocp_data &= ~FC_PATCH_TASK;
+	ocp_write_word(tp, MCU_TYPE_USB, USB_FW_TASK, ocp_data);
+	usleep_range(1000, 2000);
+	ocp_data |= FC_PATCH_TASK;
+	ocp_write_word(tp, MCU_TYPE_USB, USB_FW_TASK, ocp_data);
+
+	return rtl_enable(tp);
+}
+
 static int rtl8152_set_speed(struct r8152 *tp, u8 autoneg, u32 speed, u8 duplex,
 			     u32 advertising)
 {
@@ -7736,6 +8571,7 @@ static int rtl8152_set_speed(struct r8152 *tp, u8 autoneg, u32 speed, u8 duplex,
 				tp->ups_info.speed_duplex = NWAY_1000M_FULL;
 				break;
 			}
+			/* fall through */
 		default:
 			ret = -EINVAL;
 			goto out;
@@ -7748,76 +8584,73 @@ static int rtl8152_set_speed(struct r8152 *tp, u8 autoneg, u32 speed, u8 duplex,
 
 		tp->mii.force_media = 1;
 	} else {
-		u16 anar, tmp1;
+		u16 orig, new1;
 		u32 support;
 
-		support = ADVERTISED_10baseT_Half | ADVERTISED_10baseT_Full |
-			  ADVERTISED_100baseT_Half |
-			  ADVERTISED_100baseT_Full;
+		support = RTL_ADVERTISED_10_HALF | RTL_ADVERTISED_10_FULL |
+			  RTL_ADVERTISED_100_HALF | RTL_ADVERTISED_100_FULL;
 
 		if (tp->mii.supports_gmii) {
-			support |= ADVERTISED_1000baseT_Full;
+			support |= RTL_ADVERTISED_1000_FULL;
 
-			if (test_bit(SUPPORT_2500FULL, &tp->flags))
-				support |= ADVERTISED_2500baseX_Full;
+			if (tp->support_2500full)
+				support |= RTL_ADVERTISED_2500_FULL;
 		}
 
 		if (!(advertising & support))
 			return -EINVAL;
 
-		anar = r8152_mdio_read(tp, MII_ADVERTISE);
-		tmp1 = anar & ~(ADVERTISE_10HALF | ADVERTISE_10FULL |
+		orig = r8152_mdio_read(tp, MII_ADVERTISE);
+		new1 = orig & ~(ADVERTISE_10HALF | ADVERTISE_10FULL |
 				ADVERTISE_100HALF | ADVERTISE_100FULL);
-		if (advertising & ADVERTISED_10baseT_Half) {
-			tmp1 |= ADVERTISE_10HALF;
+		if (advertising & RTL_ADVERTISED_10_HALF) {
+			new1 |= ADVERTISE_10HALF;
 			tp->ups_info.speed_duplex = NWAY_10M_HALF;
 		}
-		if (advertising & ADVERTISED_10baseT_Full) {
-			tmp1 |= ADVERTISE_10FULL;
+		if (advertising & RTL_ADVERTISED_10_FULL) {
+			new1 |= ADVERTISE_10FULL;
 			tp->ups_info.speed_duplex = NWAY_10M_FULL;
 		}
 
-		if (advertising & ADVERTISED_100baseT_Half) {
-			tmp1 |= ADVERTISE_100HALF;
+		if (advertising & RTL_ADVERTISED_100_HALF) {
+			new1 |= ADVERTISE_100HALF;
 			tp->ups_info.speed_duplex = NWAY_100M_HALF;
 		}
-		if (advertising & ADVERTISED_100baseT_Full) {
-			tmp1 |= ADVERTISE_100FULL;
+		if (advertising & RTL_ADVERTISED_100_FULL) {
+			new1 |= ADVERTISE_100FULL;
 			tp->ups_info.speed_duplex = NWAY_100M_FULL;
 		}
 
-		if (anar != tmp1) {
-			r8152_mdio_write(tp, MII_ADVERTISE, tmp1);
-			tp->mii.advertising = tmp1;
+		if (orig != new1) {
+			r8152_mdio_write(tp, MII_ADVERTISE, new1);
+			tp->mii.advertising = new1;
 		}
 
 		if (tp->mii.supports_gmii) {
-			u16 gbcr, tmp2 = 0;
-
-			gbcr = r8152_mdio_read(tp, MII_CTRL1000);
-			tmp2 = gbcr & ~(ADVERTISE_1000FULL |
+			orig = r8152_mdio_read(tp, MII_CTRL1000);
+			new1 = orig & ~(ADVERTISE_1000FULL |
 					ADVERTISE_1000HALF);
 
-			if (advertising & ADVERTISED_1000baseT_Half) {
-				tmp2 |= ADVERTISE_1000HALF;
-				tp->ups_info.speed_duplex = NWAY_1000M_FULL;
-			}
-			if (advertising & ADVERTISED_1000baseT_Full) {
-				tmp2 |= ADVERTISE_1000FULL;
+			if (advertising & RTL_ADVERTISED_1000_FULL) {
+				new1 |= ADVERTISE_1000FULL;
 				tp->ups_info.speed_duplex = NWAY_1000M_FULL;
 			}
 
-			if (gbcr != tmp2)
-				r8152_mdio_write(tp, MII_CTRL1000, tmp2);
+			if (orig != new1)
+				r8152_mdio_write(tp, MII_CTRL1000, new1);
+		}
 
-			gbcr = ocp_reg_read(tp, 0xa5d4);
-			tmp2 = gbcr & ~BIT(7);
+		if (tp->support_2500full) {
+			orig = ocp_reg_read(tp, 0xa5d4);
+			new1 = orig & ~BIT(7);
 
-			if (advertising & ADVERTISED_2500baseX_Full)
-				tmp2 |= BIT(7);
+			if (advertising & RTL_ADVERTISED_2500_FULL) {
+				new1 |= BIT(7);
+				tp->ups_info.speed_duplex = NWAY_2500M_FULL;
+			}
 
-			if (gbcr != tmp2)
-				ocp_reg_write(tp, 0xa5d4, tmp2);
+			if (orig != new1)
+				ocp_reg_write(tp, 0xa5d4, new1);
 		}
 
 		bmcr = BMCR_ANENABLE | BMCR_ANRESTART;
@@ -7868,7 +8701,7 @@ static bool rtl_speed_down(struct r8152 *tp)
 				gbcr = r8152_mdio_read(tp, MII_CTRL1000);
 				gbcr &= ~(ADVERTISE_1000FULL |
 					  ADVERTISE_1000HALF);
-				if (test_bit(SUPPORT_2500FULL, &tp->flags)) {
+				if (tp->support_2500full) {
 					gbcr2 = ocp_reg_read(tp, 0xa5d4);
 					gbcr2 &= ~BIT(7);
 				}
@@ -7886,7 +8719,7 @@ static bool rtl_speed_down(struct r8152 *tp)
 
 			if (tp->mii.supports_gmii) {
 				r8152_mdio_write(tp, MII_CTRL1000, gbcr);
-				if (test_bit(SUPPORT_2500FULL, &tp->flags))
+				if (tp->support_2500full)
 					ocp_reg_write(tp, 0xa5d4, gbcr2);
 			}
 
@@ -7923,10 +8756,6 @@ static void rtl8152_down(struct r8152 *tp)
 	r8152_aldps_en(tp, false);
 	r8152b_enter_oob(tp);
 	r8152_aldps_en(tp, true);
-	if (tp->version == RTL_VER_01)
-		rtl8152_set_speed(tp, AUTONEG_ENABLE, 0, 0, 3);
-	else
-		rtl_speed_down(tp);
 }
 
 static void rtl8153_up(struct r8152 *tp)
@@ -7942,27 +8771,29 @@ static void rtl8153_up(struct r8152 *tp)
 	r8153_mac_clk_spd(tp, false);
 	r8153_first_init(tp);
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xe90a);
-	ocp_data |= BIT(0);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xe90a, ocp_data);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CONFIG6);
+	ocp_data |= LANWAKE_CLR_EN;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CONFIG6, ocp_data);
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xe007);
-	ocp_data &= ~BIT(7);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xe007, ocp_data);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_LWAKE_CTRL_REG);
+	ocp_data &= ~LANWAKE_PIN;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_LWAKE_CTRL_REG, ocp_data);
 
-	if (!work_busy(&tp->hw_phy_work.work)) {
-		r8153_aldps_en(tp, true);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_SSPHYLINK1);
+	ocp_data &= ~DELAY_PHY_PWR_CHG;
+	ocp_write_word(tp, MCU_TYPE_USB, USB_SSPHYLINK1, ocp_data);
 
-		switch (tp->version) {
-		case RTL_VER_03:
-		case RTL_VER_04:
-			break;
-		case RTL_VER_05:
-		case RTL_VER_06:
-		default:
-			r8153_u2p3en(tp, true);
-			break;
-		}
+	r8153_aldps_en(tp, true);
+
+	switch (tp->version) {
+	case RTL_VER_03:
+	case RTL_VER_04:
+		break;
+	case RTL_VER_05:
+	case RTL_VER_06:
+	default:
+		r8153_u2p3en(tp, true);
+		break;
 	}
 
 	r8153_u1u2en(tp, true);
@@ -7977,9 +8808,9 @@ static void rtl8153_down(struct r8152 *tp)
 		return;
 	}
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xe90a);
-	ocp_data &= ~BIT(0);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xe90a, ocp_data);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CONFIG6);
+	ocp_data &= ~LANWAKE_CLR_EN;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CONFIG6, ocp_data);
 
 	r8153_u1u2en(tp, false);
 	r8153_u2p3en(tp, false);
@@ -7988,7 +8819,6 @@ static void rtl8153_down(struct r8152 *tp)
 	r8153_mac_clk_spd(tp, true);
 	r8153_enter_oob(tp);
 	r8153_aldps_en(tp, true);
-	rtl_speed_down(tp);
 }
 
 static void rtl8153b_up(struct r8152 *tp)
@@ -8006,15 +8836,13 @@ static void rtl8153b_up(struct r8152 *tp)
 	ocp_write_dword(tp, MCU_TYPE_USB, USB_RX_BUF_TH, RX_THR_B);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
-	ocp_data &= ~BIT(14);
+	ocp_data &= ~PLA_MCU_SPDWN_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
 
-	if (!work_busy(&tp->hw_phy_work.work)) {
-		r8153_aldps_en(tp, true);
-//		r8153_u2p3en(tp, true);
-	}
-
-	r8153b_u1u2en(tp, true);
+	r8153_aldps_en(tp, true);
+//	r8153_u2p3en(tp, true);
+	if (tp->udev->speed >= USB_SPEED_SUPER)
+		r8153b_u1u2en(tp, true);
 }
 
 static void rtl8153b_down(struct r8152 *tp)
@@ -8027,7 +8855,7 @@ static void rtl8153b_down(struct r8152 *tp)
 	}
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
-	ocp_data |= BIT(14);
+	ocp_data |= PLA_MCU_SPDWN_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
 
 	r8153b_u1u2en(tp, false);
@@ -8036,7 +8864,28 @@ static void rtl8153b_down(struct r8152 *tp)
 	r8153_aldps_en(tp, false);
 	r8153_enter_oob(tp);
 	r8153_aldps_en(tp, true);
-	rtl_speed_down(tp);
+}
+
+static void r8156_fc_parameter(struct r8152 *tp)
+{
+	u32 base = ALIGN(tp->netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN, 1024);
+	u32 fc_pause = tp->fc_pause ? tp->fc_pause : (base + 0x800);
+	u32 fc_restart = tp->fc_restart ? tp->fc_restart : (base + 0x1800);
+
+	switch (tp->version) {
+	case RTL_VER_10:
+	case RTL_VER_11:
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xc0a6, fc_pause / 8);
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xc0aa, fc_restart / 8);
+		break;
+	case RTL_VER_12:
+	case RTL_VER_13:
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xc0a6, fc_pause / 16);
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xc0aa, fc_restart / 16);
+		break;
+	default:
+		break;
+	}
 }
 
 static void rtl8156_up(struct r8152 *tp)
@@ -8057,7 +8906,7 @@ static void rtl8156_up(struct r8152 *tp)
 	ocp_data &= ~RCR_ACPT_ALL;
 	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_RCR, ocp_data);
 
-	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CR, 0);
+	rtl8152_nic_reset(tp);
 	rtl_reset_bmu(tp);
 
 	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_OOB_CTRL);
@@ -8074,32 +8923,44 @@ static void rtl8156_up(struct r8152 *tp)
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RMS, ocp_data);
 	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_MTPS, MTPS_JUMBO);
 
+	switch (tp->version) {
+	case RTL_VER_10:
+	case RTL_VER_11:
+		r8156_fc_parameter(tp);
+
+		/* TX share fifo free credit full threshold */
+		ocp_write_dword(tp, MCU_TYPE_PLA, PLA_TXFIFO_CTRL,
+				TXFIFO_THR_NORMAL2);
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd4b4);
+		ocp_data |= BIT(1);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd4b4, ocp_data);
+		break;
+	case RTL_VER_12:
+	case RTL_VER_13:
+	default:
+		r8156_fc_parameter(tp);
+
+		/* TX share fifo free credit full threshold */
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_TXFIFO_CTRL, 0x0008);
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xe61a,
+			       (ocp_data + 0x800) / 16);
+		break;
+	}
+
 	/* share FIFO settings */
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xc0a2);
 	ocp_data &= ~0xfff;
 	ocp_data |= 0x08;
 	ocp_write_word(tp, MCU_TYPE_PLA, 0xc0a2, ocp_data);
 
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xc0a6);
-	ocp_data &= ~0xfff;
-	ocp_data |= 0x0100;
-	ocp_write_word(tp, MCU_TYPE_PLA, 0xc0a6, ocp_data);
-
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xc0a8);
-	ocp_data &= ~0xfff;
-	ocp_data |= 0x0200;
-	ocp_write_word(tp, MCU_TYPE_PLA, 0xc0a8, ocp_data);
-
-	/* TX share fifo free credit full threshold */
-	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_TXFIFO_CTRL, TXFIFO_THR_NORMAL2);
-
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
-	ocp_data &= ~BIT(14);
+	ocp_data &= ~PLA_MCU_SPDWN_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
 
-//	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd32a);
-//	ocp_data &= ~(BIT(8) | BIT(9));
-//	ocp_write_word(tp, MCU_TYPE_USB, 0xd32a, ocp_data);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd32a);
+	ocp_data &= ~(BIT(8) | BIT(9));
+	ocp_write_word(tp, MCU_TYPE_USB, 0xd32a, ocp_data);
 
 	ocp_write_dword(tp, MCU_TYPE_USB, USB_RX_BUF_TH, 0x00600400);
 
@@ -8108,12 +8969,11 @@ static void rtl8156_up(struct r8152 *tp)
 		__rtl_set_wol(tp, tp->saved_wolopts);
 	}
 
-	if (!work_busy(&tp->hw_phy_work.work)) {
-		r8153_aldps_en(tp, true);
-		r8153_u2p3en(tp, true);
-	}
+	r8153_aldps_en(tp, true);
+	r8153_u2p3en(tp, true);
 
-	r8153b_u1u2en(tp, true);
+	if (tp->udev->speed >= USB_SPEED_SUPER)
+		r8153b_u1u2en(tp, true);
 }
 
 static void rtl8156_down(struct r8152 *tp)
@@ -8126,7 +8986,7 @@ static void rtl8156_down(struct r8152 *tp)
 	}
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
-	ocp_data |= BIT(14);
+	ocp_data |= PLA_MCU_SPDWN_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
 
 	r8153b_u1u2en(tp, false);
@@ -8159,7 +9019,6 @@ static void rtl8156_down(struct r8152 *tp)
 	ocp_write_dword(tp, MCU_TYPE_PLA, PLA_RCR, ocp_data);
 
 	r8153_aldps_en(tp, true);
-	rtl_speed_down(tp);
 }
 
 static bool rtl8152_in_nway(struct r8152 *tp)
@@ -8361,6 +9220,11 @@ static int rtl8152_open(struct net_device *netdev)
 	if (unlikely(tp->rtk_enable_diag))
 		return -EBUSY;
 
+	if (work_busy(&tp->hw_phy_work.work) & WORK_BUSY_PENDING) {
+		cancel_delayed_work_sync(&tp->hw_phy_work);
+		__rtl_hw_phy_work_func(tp);
+	}
+
 	res = alloc_all_mem(tp);
 	if (res)
 		goto out;
@@ -8421,12 +9285,12 @@ static int rtl8152_close(struct net_device *netdev)
 	unregister_pm_notifier(&tp->pm_notifier);
 #endif
 	tasklet_disable(&tp->tx_tl);
-	napi_disable(&tp->napi);
 	smp_mb__before_atomic();
 	clear_bit(WORK_ENABLE, &tp->flags);
 	smp_mb__after_atomic();
 	usb_kill_urb(tp->intr_urb);
 	cancel_delayed_work_sync(&tp->schedule);
+	napi_disable(&tp->napi);
 	netif_stop_queue(netdev);
 
 	if (unlikely(tp->rtk_enable_diag)) {
@@ -8442,6 +9306,12 @@ static int rtl8152_close(struct net_device *netdev)
 		mutex_lock(&tp->control);
 
 		tp->rtl_ops.down(tp);
+
+		if (tp->version == RTL_VER_01)
+			rtl8152_set_speed(tp, AUTONEG_ENABLE, 0, 0, 3);
+		else
+			rtl_speed_down(tp);
+
 #if defined(RTL8152_S5_WOL) && defined(CONFIG_PM)
 		res = rtl_s5_wol(tp);
 #endif
@@ -8591,17 +9461,17 @@ static void r8153_init(struct r8152 *tp)
 
 		r8153_queue_wake(tp, false);
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xd398);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS);
 		if (rtl8152_get_speed(tp) & LINK_STATUS)
-			ocp_data |= BIT(15);
+			ocp_data |= CUR_LINK_OK;
 		else
-			ocp_data &= ~BIT(15);
+			ocp_data &= ~CUR_LINK_OK;
 
 		/* r8153_queue_wake() has set this bit */
 		/* ocp_data &= ~BIT(8); */
 
-		ocp_data |= BIT(0);
-		ocp_write_word(tp, MCU_TYPE_PLA, 0xd398, ocp_data);
+		ocp_data |= POLL_LINK_CHG;
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS, ocp_data);
 	}
 
 	ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, USB_CSR_DUMMY2);
@@ -8636,13 +9506,13 @@ static void r8153_init(struct r8152 *tp)
 	r8153_mac_clk_spd(tp, false);
 	usb_enable_lpm(tp->udev);
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xe90a);
-	ocp_data |= BIT(0);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xe90a, ocp_data);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_CONFIG6);
+	ocp_data |= LANWAKE_CLR_EN;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_CONFIG6, ocp_data);
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xe007);
-	ocp_data &= ~BIT(7);
-	ocp_write_byte(tp, MCU_TYPE_PLA, 0xe007, ocp_data);
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, PLA_LWAKE_CTRL_REG);
+	ocp_data &= ~LANWAKE_PIN;
+	ocp_write_byte(tp, MCU_TYPE_PLA, PLA_LWAKE_CTRL_REG, ocp_data);
 
 	/* rx aggregation */
 	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
@@ -8705,23 +9575,25 @@ static void r8153b_init(struct r8152 *tp)
 	r8153_queue_wake(tp, false);
 	rtl_runtime_suspend_enable(tp, false);
 
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xd398);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS);
 	if (rtl8152_get_speed(tp) & LINK_STATUS)
-		ocp_data |= BIT(15);
+		ocp_data |= CUR_LINK_OK;
 	else
-		ocp_data &= ~BIT(15);
+		ocp_data &= ~CUR_LINK_OK;
 
 	/* r8153_queue_wake() has set this bit */
 	/* ocp_data &= ~BIT(8); */
 
-	ocp_data |= BIT(0);
-	ocp_write_word(tp, MCU_TYPE_PLA, 0xd398, ocp_data);
+	ocp_data |= POLL_LINK_CHG;
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS, ocp_data);
 
 	if (tp->udev->descriptor.idVendor == VENDOR_ID_LENOVO &&
 	    tp->udev->descriptor.idProduct == 0x3069)
 		ocp_write_word(tp, MCU_TYPE_USB, USB_SSPHYLINK2, 0x0c8c);
 
-	r8153b_u1u2en(tp, true);
+	if (tp->udev->speed >= USB_SPEED_SUPER)
+		r8153b_u1u2en(tp, true);
+
 	usb_enable_lpm(tp->udev);
 
 	/* MAC clock speed down */
@@ -8730,10 +9602,11 @@ static void r8153b_init(struct r8152 *tp)
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL2, ocp_data);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
-	ocp_data &= ~BIT(14);
+	ocp_data &= ~PLA_MCU_SPDWN_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
 
 	if (tp->version == RTL_VER_09) {
+		/* Disable Test IO for 32QFN */
 		if (ocp_read_byte(tp, MCU_TYPE_PLA, 0xdc00) & BIT(5)) {
 			ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_PHY_PWR);
 			ocp_data |= TEST_IO_OFF;
@@ -8762,7 +9635,7 @@ static void r8156_patch_code(struct r8152 *tp)
 			0x00, 0xb8, 0x40, 0x03,
 			0x00, 0xd4, 0x00, 0x00 };
 
-		r8153b_clear_bp(tp, MCU_TYPE_USB);
+		rtl_clear_bp(tp, MCU_TYPE_USB);
 
 		generic_ocp_write(tp, 0xe600, 0xff, sizeof(usb3_patch_t),
 				  usb3_patch_t, MCU_TYPE_USB);
@@ -8909,7 +9782,7 @@ static void r8156_patch_code(struct r8152 *tp)
 			0x6c, 0xe8, 0x20, 0xe8,
 			0x00, 0xa0, 0x38, 0xe4};
 
-		r8153b_clear_bp(tp, MCU_TYPE_USB);
+		rtl_clear_bp(tp, MCU_TYPE_USB);
 
 		generic_ocp_write(tp, 0xe600, 0xff, sizeof(usb_patch3_b),
 				  usb_patch3_b, MCU_TYPE_USB);
@@ -8934,14 +9807,14 @@ static void r8156_patch_code(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_USB, USB_BP2_EN, 0x001f);
 		ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd7, 0x03);
 
-		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xcfcc);
-		ocp_data &= ~BIT(9);
-		ocp_write_word(tp, MCU_TYPE_USB, 0xcfcc, ocp_data);
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1);
+		ocp_data |= FW_IP_RESET_EN;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1, ocp_data);
 
 		ocp_write_dword(tp, MCU_TYPE_USB, 0xd480, 0x4026840e);
 		ocp_write_dword(tp, MCU_TYPE_USB, 0xd480, 0x4001acc9);
 
-		r8153b_clear_bp(tp, MCU_TYPE_PLA);
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
 
 		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch11),
 				  pla_patch11, MCU_TYPE_PLA);
@@ -8957,15 +9830,1164 @@ static void r8156_patch_code(struct r8152 *tp)
 		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_7, 0x0000);
 		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x0003);
 		ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd6, 0x02);
+	} else if (tp->version == RTL_VER_12) {
+		static u8 usb_patch4_a[] = {
+			0x10, 0xe0, 0x38, 0xe0,
+			0x4e, 0xe0, 0x8b, 0xe0,
+			0xc1, 0xe0, 0xcd, 0xe0,
+			0xd5, 0xe0, 0xed, 0xe0,
+			0xf9, 0xe0, 0xfb, 0xe0,
+			0xfd, 0xe0, 0xff, 0xe0,
+			0x01, 0xe1, 0x03, 0xe1,
+			0x05, 0xe1, 0x07, 0xe1,
+			0x22, 0xc2, 0x4a, 0x41,
+			0x91, 0x20, 0x20, 0xc0,
+			0x16, 0x00, 0x00, 0x73,
+			0x1e, 0xc4, 0x5c, 0x41,
+			0x8b, 0x41, 0x1a, 0xc0,
+			0x1a, 0x00, 0x00, 0x73,
+			0xbd, 0x48, 0x0d, 0x18,
+			0x17, 0xc6, 0xc0, 0x88,
+			0xc1, 0x9b, 0x15, 0xe8,
+			0x0b, 0x18, 0x12, 0xc6,
+			0xc0, 0x88, 0xc1, 0x99,
+			0x10, 0xe8, 0x0c, 0xc0,
+			0x1c, 0x00, 0x00, 0x73,
+			0x0e, 0x18, 0x0a, 0xc6,
+			0xc0, 0x88, 0xc1, 0x9b,
+			0x08, 0xe8, 0x02, 0xc6,
+			0x00, 0xbe, 0x10, 0x12,
+			0xf0, 0x00, 0x90, 0xc7,
+			0x1f, 0xfe, 0x8f, 0xcb,
+			0x02, 0xc6, 0x00, 0xbe,
+			0x66, 0x3f, 0x11, 0x21,
+			0x2b, 0x25, 0x13, 0xc4,
+			0xa2, 0x41, 0x80, 0x63,
+			0xf5, 0xc0, 0x48, 0x00,
+			0xbb, 0x21, 0xb9, 0x25,
+			0x00, 0x71, 0x0c, 0xc2,
+			0x4a, 0x41, 0x8b, 0x41,
+			0x24, 0x18, 0xee, 0xc6,
+			0xc0, 0x88, 0xc1, 0x99,
+			0xec, 0xef, 0x02, 0xc6,
+			0x00, 0xbe, 0x8a, 0x12,
+			0xa0, 0xf9, 0x83, 0xff,
+			0xd4, 0x18, 0x20, 0x88,
+			0x36, 0xe8, 0x22, 0x60,
+			0x85, 0x48, 0x06, 0x48,
+			0x21, 0x88, 0xf4, 0x18,
+			0x20, 0x88, 0x32, 0xe8,
+			0x2d, 0xc3, 0xc0, 0x18,
+			0x20, 0x88, 0x2b, 0xe8,
+			0x22, 0x60, 0x60, 0x88,
+			0xc1, 0x18, 0x20, 0x88,
+			0x26, 0xe8, 0x22, 0x60,
+			0x61, 0x88, 0xc2, 0x18,
+			0x20, 0x88, 0x21, 0xe8,
+			0x22, 0x60, 0x62, 0x88,
+			0xc3, 0x18, 0x20, 0x88,
+			0x1c, 0xe8, 0x22, 0x60,
+			0x63, 0x88, 0xc4, 0x18,
+			0x20, 0x88, 0x17, 0xe8,
+			0x22, 0x60, 0x64, 0x88,
+			0xc5, 0x18, 0x20, 0x88,
+			0x12, 0xe8, 0x22, 0x60,
+			0x65, 0x88, 0xc6, 0x18,
+			0x20, 0x88, 0x0d, 0xe8,
+			0x22, 0x60, 0x66, 0x88,
+			0xc7, 0x18, 0x20, 0x88,
+			0x08, 0xe8, 0x22, 0x60,
+			0x67, 0x88, 0xd4, 0x18,
+			0x02, 0xc5, 0x00, 0xbd,
+			0xc2, 0x35, 0xc0, 0xd3,
+			0x02, 0xc5, 0x00, 0xbd,
+			0xb2, 0x3e, 0x02, 0xc5,
+			0x00, 0xbd, 0x08, 0x3f,
+			0xd4, 0x18, 0xc0, 0x88,
+			0xf8, 0xef, 0xc2, 0x60,
+			0x85, 0x48, 0x06, 0x48,
+			0xc1, 0x88, 0xf4, 0x18,
+			0xc0, 0x88, 0xf4, 0xef,
+			0xef, 0xc3, 0x60, 0x60,
+			0xc1, 0x88, 0xe0, 0x18,
+			0xc0, 0x88, 0xee, 0xef,
+			0x61, 0x60, 0xc1, 0x88,
+			0xe1, 0x18, 0xc0, 0x88,
+			0xe9, 0xef, 0x62, 0x60,
+			0xc1, 0x88, 0xe2, 0x18,
+			0xc0, 0x88, 0xe4, 0xef,
+			0x63, 0x60, 0xc1, 0x88,
+			0xe3, 0x18, 0xc0, 0x88,
+			0xdf, 0xef, 0x64, 0x60,
+			0xc1, 0x88, 0xe4, 0x18,
+			0xc0, 0x88, 0xda, 0xef,
+			0x65, 0x60, 0xc1, 0x88,
+			0xe5, 0x18, 0xc0, 0x88,
+			0xd5, 0xef, 0x66, 0x60,
+			0xc1, 0x88, 0xe6, 0x18,
+			0xc0, 0x88, 0xd0, 0xef,
+			0x67, 0x60, 0xc1, 0x88,
+			0xe7, 0x18, 0xc0, 0x88,
+			0xcb, 0xef, 0xd4, 0x18,
+			0x02, 0xc2, 0x00, 0xba,
+			0x3a, 0x15, 0x0b, 0xc6,
+			0xc7, 0x65, 0xd0, 0x49,
+			0x05, 0xf1, 0x08, 0xc0,
+			0x02, 0xc6, 0x00, 0xbe,
+			0x50, 0x2f, 0x02, 0xc7,
+			0x00, 0xbf, 0x56, 0x2f,
+			0x20, 0xd4, 0x00, 0xd4,
+			0x08, 0xc3, 0x60, 0x60,
+			0x03, 0x48, 0x60, 0x88,
+			0x00, 0x1b, 0x02, 0xc6,
+			0x00, 0xbe, 0xda, 0x2c,
+			0x60, 0xb4, 0x17, 0xc1,
+			0x17, 0xc2, 0x4c, 0x99,
+			0x00, 0x19, 0x4e, 0x89,
+			0x4f, 0x61, 0x97, 0x49,
+			0xfe, 0xf1, 0x48, 0x61,
+			0x01, 0xb4, 0x16, 0x48,
+			0x17, 0x48, 0x48, 0x89,
+			0x0a, 0xc1, 0x4c, 0x99,
+			0x81, 0x19, 0x4e, 0x89,
+			0x4f, 0x61, 0x97, 0x49,
+			0xfe, 0xf1, 0x02, 0xc0,
+			0x00, 0xb8, 0x32, 0x7c,
+			0x1c, 0xe8, 0x00, 0xdc,
+			0x01, 0xb0, 0xfe, 0xc2,
+			0x48, 0x89, 0xfb, 0xc1,
+			0x4c, 0x99, 0x81, 0x19,
+			0x4e, 0x89, 0x4f, 0x61,
+			0x97, 0x49, 0xfe, 0xf1,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x96, 0x7c, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x00, 0x00};
+		static u8 pla_patch4_a[] = {
+			0x08, 0xe0, 0x0c, 0xe0,
+			0x10, 0xe0, 0x3e, 0xe0,
+			0x40, 0xe0, 0x42, 0xe0,
+			0x44, 0xe0, 0x46, 0xe0,
+			0x03, 0xb4, 0x02, 0xb4,
+			0x02, 0xc7, 0x00, 0xbf,
+			0xb4, 0x03, 0x02, 0xb0,
+			0x03, 0xb0, 0x02, 0xc6,
+			0x00, 0xbe, 0x8c, 0x05,
+			0xaf, 0x49, 0x17, 0xf1,
+			0x20, 0xc6, 0x00, 0x1a,
+			0x23, 0xe8, 0x21, 0xc6,
+			0xc0, 0x61, 0x91, 0x49,
+			0x0c, 0xf0, 0x95, 0x49,
+			0x0a, 0xf1, 0x14, 0x48,
+			0x16, 0xc6, 0x81, 0x1a,
+			0x19, 0xe8, 0x14, 0xc6,
+			0xc0, 0x62, 0x24, 0x48,
+			0xc0, 0x8a, 0x0c, 0xe0,
+			0x10, 0xc6, 0xc0, 0x62,
+			0xa5, 0x49, 0x08, 0xf1,
+			0x0d, 0xc6, 0xc0, 0x62,
+			0xa0, 0x48, 0xc0, 0x8a,
+			0xc2, 0x62, 0xa3, 0x48,
+			0xc2, 0x8a, 0x02, 0xc6,
+			0x00, 0xbe, 0xd2, 0x16,
+			0x84, 0xd2, 0x6a, 0xdc,
+			0x90, 0xd3, 0x66, 0xb4,
+			0x08, 0xea, 0xff, 0xc0,
+			0x04, 0x9e, 0x00, 0x99,
+			0x06, 0x8a, 0x06, 0x72,
+			0xaf, 0x49, 0xfe, 0xf1,
+			0x80, 0xff, 0x02, 0xc6,
+			0x00, 0xbe, 0x00, 0x00,
+			0x02, 0xc6, 0x00, 0xbe,
+			0x00, 0x00, 0x02, 0xc6,
+			0x00, 0xbe, 0x00, 0x00,
+			0x02, 0xc6, 0x00, 0xbe,
+			0x00, 0x00, 0x02, 0xc6,
+			0x00, 0xbe, 0x00, 0x00};
+
+		rtl_clear_bp(tp, MCU_TYPE_USB);
+
+		generic_ocp_write(tp, 0xe600, 0xff, sizeof(usb_patch4_a),
+				  usb_patch4_a, MCU_TYPE_USB);
+
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_BA, 0xc000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_0, 0x11e2);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_1, 0x1268);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_2, 0x35c0);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_3, 0x1538);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_4, 0x2f4e);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_5, 0x2cd8);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_6, 0x7c26);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_7, 0x7c90);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_8, 0x0000);
+//		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_9, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_10, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_11, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_12, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_13, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_14, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_15, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP2_EN, 0x00df);
+		ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd7, 0x02);
+
+//		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1);
+//		ocp_data |= FW_IP_RESET_EN;
+//		ocp_write_word(tp, MCU_TYPE_USB, USB_FW_FIX_EN1, ocp_data);
+
+//		ocp_write_dword(tp, MCU_TYPE_USB, 0xd480, 0x4026840e);
+//		ocp_write_dword(tp, MCU_TYPE_USB, 0xd480, 0x4001acc9);
+
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
+
+		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch4_a),
+				  pla_patch4_a, MCU_TYPE_PLA);
+
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_BA, 0x8000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_0, 0x03b2);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_1, 0x058a);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_2, 0x16c0);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_3, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_4, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_5, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_6, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_7, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x0007);
+		ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd6, 0x02);
+	} else if (tp->version == RTL_VER_13) {
+		static u8 usb_patch_13[] = {
+			0x10, 0xe0, 0x25, 0xe0,
+			0x29, 0xe0, 0x2d, 0xe0,
+			0x52, 0xe0, 0xff, 0xe0,
+			0x02, 0xe1, 0x0b, 0xe1,
+			0x0d, 0xe1, 0x0f, 0xe1,
+			0x11, 0xe1, 0x13, 0xe1,
+			0x15, 0xe1, 0x17, 0xe1,
+			0x19, 0xe1, 0x1b, 0xe1,
+			0x13, 0xc3, 0x60, 0x70,
+			0x8b, 0x49, 0x0d, 0xf1,
+			0x10, 0xc3, 0x60, 0x60,
+			0x85, 0x49, 0x09, 0xf1,
+			0x40, 0x03, 0x64, 0x60,
+			0x82, 0x49, 0x05, 0xf1,
+			0x09, 0xc3, 0x60, 0x60,
+			0x80, 0x48, 0x60, 0x88,
+			0x02, 0xc0, 0x00, 0xb8,
+			0xde, 0x0f, 0xca, 0xcf,
+			0x00, 0xd8, 0x1e, 0xb4,
+			0x04, 0xc3, 0x02, 0xc0,
+			0x00, 0xb8, 0x62, 0x36,
+			0xc8, 0xd3, 0x04, 0xc3,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x7a, 0x14, 0xc8, 0xd3,
+			0x00, 0xb4, 0x01, 0xb4,
+			0x02, 0xb4, 0x03, 0xb4,
+			0x1f, 0xc1, 0x02, 0x1b,
+			0x2c, 0x8b, 0x0c, 0x62,
+			0xa7, 0x49, 0x0a, 0xf1,
+			0x00, 0x1b, 0x08, 0x72,
+			0x13, 0x40, 0x04, 0xf1,
+			0x0a, 0x72, 0x13, 0x40,
+			0x03, 0xf0, 0x01, 0x1b,
+			0x2c, 0x8b, 0x12, 0xc0,
+			0x01, 0x1a, 0x08, 0x8a,
+			0x0a, 0x8a, 0x0d, 0xc0,
+			0x12, 0x71, 0x19, 0x48,
+			0x1a, 0x48, 0x12, 0x99,
+			0x03, 0xb0, 0x02, 0xb0,
+			0x01, 0xb0, 0x00, 0xb0,
+			0x02, 0xc0, 0x00, 0xb8,
+			0xb0, 0x77, 0x20, 0xc3,
+			0x18, 0xb4, 0x80, 0xcb,
+			0x00, 0xb4, 0x01, 0xb4,
+			0x02, 0xb4, 0x03, 0xb4,
+			0x07, 0xb4, 0x23, 0xc0,
+			0x24, 0xc1, 0x08, 0x1a,
+			0x2a, 0x8a, 0x24, 0x01,
+			0x0d, 0x1a, 0x20, 0x9a,
+			0x24, 0x09, 0x00, 0x1a,
+			0x22, 0x9a, 0x04, 0x72,
+			0x06, 0x73, 0x18, 0xc7,
+			0xe4, 0x9a, 0xe6, 0x9b,
+			0x17, 0xc2, 0x17, 0xc3,
+			0xe0, 0x9a, 0xe2, 0x9b,
+			0x80, 0x1b, 0x32, 0x8b,
+			0x00, 0x1a, 0x24, 0x9f,
+			0x26, 0x9a, 0x01, 0x1a,
+			0x28, 0x8a, 0x0f, 0xe8,
+			0x07, 0xb0, 0x03, 0xb0,
+			0x02, 0xb0, 0x01, 0xb0,
+			0x00, 0xb0, 0x02, 0xc6,
+			0x00, 0xbe, 0xe6, 0x60,
+			0x00, 0xc3, 0x20, 0xc3,
+			0x80, 0xcb, 0x55, 0x53,
+			0x42, 0x53, 0x80, 0xcb,
+			0x03, 0xb4, 0x06, 0xb4,
+			0x07, 0xb4, 0xfc, 0xc7,
+			0x79, 0xc7, 0xe0, 0x73,
+			0xba, 0x49, 0x0d, 0xf0,
+			0xf7, 0xc6, 0x24, 0x06,
+			0xc0, 0x77, 0xfa, 0x25,
+			0x76, 0x23, 0x66, 0x27,
+			0x70, 0xc7, 0xe1, 0x9e,
+			0x00, 0x16, 0x10, 0xf0,
+			0x01, 0x03, 0x0e, 0xe0,
+			0xb9, 0x49, 0x10, 0xf0,
+			0xe9, 0xc6, 0x24, 0x06,
+			0xc0, 0x77, 0xf9, 0x25,
+			0x77, 0x23, 0x67, 0x27,
+			0x62, 0xc7, 0xe1, 0x9e,
+			0x00, 0x16, 0x02, 0xf0,
+			0x01, 0x03, 0x5e, 0xc7,
+			0xe0, 0x8b, 0x12, 0xe8,
+			0x0d, 0xe0, 0xda, 0xc6,
+			0x24, 0x06, 0xc0, 0x77,
+			0xf6, 0x25, 0x7a, 0x23,
+			0x6a, 0x27, 0x53, 0xc7,
+			0xe1, 0x9e, 0x00, 0x16,
+			0xf3, 0xf0, 0x01, 0x03,
+			0xf1, 0xe7, 0x07, 0xb0,
+			0x06, 0xb0, 0x03, 0xb0,
+			0x80, 0xff, 0x03, 0xb4,
+			0x06, 0xb4, 0x07, 0xb4,
+			0xc7, 0xc6, 0xc4, 0x77,
+			0x40, 0xc3, 0x7c, 0x9f,
+			0x41, 0xc6, 0xc0, 0x73,
+			0xba, 0x49, 0x05, 0xf1,
+			0x00, 0x13, 0x05, 0xf1,
+			0x39, 0xc3, 0x04, 0xe0,
+			0x38, 0xc3, 0x02, 0xe0,
+			0x40, 0x1b, 0xb8, 0xc6,
+			0xfb, 0x31, 0xc4, 0x9f,
+			0x35, 0xc6, 0xc0, 0x67,
+			0x01, 0x17, 0x07, 0xfc,
+			0x30, 0xc6, 0xc1, 0x77,
+			0x01, 0x1b, 0xc0, 0x8b,
+			0x00, 0x17, 0x0c, 0xf1,
+			0x29, 0xc6, 0xc0, 0x73,
+			0xba, 0x49, 0x05, 0xf1,
+			0xb9, 0x49, 0x05, 0xf0,
+			0x21, 0xc7, 0x04, 0xe0,
+			0x20, 0xc7, 0x02, 0xe0,
+			0x40, 0x1f, 0x1a, 0xc6,
+			0x7e, 0x41, 0x1d, 0xc6,
+			0xc0, 0x63, 0xbb, 0x21,
+			0xbb, 0x41, 0x15, 0xc3,
+			0x66, 0x9f, 0x18, 0xc6,
+			0xc0, 0x67, 0xf9, 0x3b,
+			0xc0, 0x8f, 0x01, 0x17,
+			0x03, 0xfd, 0x00, 0x1f,
+			0x02, 0xe0, 0x01, 0x1f,
+			0x0e, 0xc6, 0xc0, 0x8f,
+			0x08, 0xc3, 0x04, 0x1e,
+			0x60, 0x8e, 0x07, 0xb0,
+			0x06, 0xb0, 0x03, 0xb0,
+			0x80, 0xff, 0xff, 0x07,
+			0x40, 0xd4, 0x00, 0x02,
+			0x00, 0x04, 0x80, 0xb9,
+			0xfd, 0xcb, 0xa2, 0xcb,
+			0xe8, 0x74, 0x02, 0xc5,
+			0x00, 0xbd, 0x96, 0x6d,
+			0x08, 0xc7, 0xe0, 0x71,
+			0x9e, 0x48, 0xe0, 0x99,
+			0x05, 0xc7, 0x02, 0xc1,
+			0x00, 0xb9, 0x24, 0x3f,
+			0x00, 0xcf, 0x00, 0xd8,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x3a, 0x4e, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x00, 0x00};
+		static u8 pla_patch_13[] = {
+			0x10, 0xe0, 0x1c, 0xe0,
+			0x20, 0xe0, 0x22, 0xe0,
+			0x24, 0xe0, 0x26, 0xe0,
+			0x28, 0xe0, 0x2a, 0xe0,
+			0x2c, 0xe0, 0x2e, 0xe0,
+			0x30, 0xe0, 0x32, 0xe0,
+			0x34, 0xe0, 0x36, 0xe0,
+			0x38, 0xe0, 0x3a, 0xe0,
+			0x0c, 0xc4, 0x04, 0x40,
+			0x05, 0xf0, 0x8c, 0x26,
+			0x0b, 0x15, 0x02, 0xf0,
+			0x03, 0xe0, 0x00, 0x9a,
+			0x01, 0xe0, 0x02, 0xc4,
+			0x00, 0xbc, 0x36, 0x37,
+			0x6c, 0xe8, 0x3a, 0x73,
+			0xbb, 0x49, 0x02, 0xc6,
+			0x00, 0xbe, 0xde, 0x27,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x3a, 0x4e, 0x02, 0xc0,
+			0x00, 0xb8, 0x3a, 0x4e,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x3a, 0x4e, 0x02, 0xc0,
+			0x00, 0xb8, 0x3a, 0x4e,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x3a, 0x4e, 0x02, 0xc0,
+			0x00, 0xb8, 0x3a, 0x4e,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00,
+			0x02, 0xc0, 0x00, 0xb8,
+			0x00, 0x00, 0x02, 0xc0,
+			0x00, 0xb8, 0x00, 0x00};
+
+		rtl_clear_bp(tp, MCU_TYPE_USB);
+
+		generic_ocp_write(tp, 0xe600, 0xff, sizeof(usb_patch_13),
+				  usb_patch_13, MCU_TYPE_USB);
+
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_BA, 0xc000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_0, 0x0fba);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_1, 0x3660);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_2, 0x1478);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_3, 0x77ae);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_4, 0x60e0);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_5, 0x6d94);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_6, 0x3f22);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_7, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_8, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_9, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_10, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_11, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_12, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_13, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_14, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP_15, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_USB, USB_BP2_EN, 0x007f);
+		ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd7, 0x02);
+
+		rtl_clear_bp(tp, MCU_TYPE_PLA);
+
+		generic_ocp_write(tp, 0xf800, 0xff, sizeof(pla_patch_13),
+				  pla_patch_13, MCU_TYPE_PLA);
+
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_BA, 0x8000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_0, 0x374e);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_1, 0x27dc);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_2, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_3, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_4, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_5, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_6, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_7, 0x0000);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_BP_EN, 0x0003);
+		ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd6, 0x02);
 	}
 }
 
-static void r8156_ram_code(struct r8152 *tp)
+static void rtl_ram_code_speed_up(struct r8152 *tp)
+{
+	u32 ocp_data, len = 0;
+	u8 *data = NULL;
+
+	if (tp->version == RTL_VER_13) {
+		static u8 ram13[] = {
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x24, 0x80,
+			0x38, 0xb4, 0x01, 0x37,
+			0x36, 0xb4, 0x2e, 0xb8,
+			0x38, 0xb4, 0x01, 0x00,
+			0x6c, 0xe8, 0x00, 0xb0,
+			0x20, 0xb8, 0x90, 0x00,
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x16, 0xa0,
+			0x38, 0xb4, 0x00, 0x00,
+			0x36, 0xb4, 0x12, 0xa0,
+			0x38, 0xb4, 0x00, 0x00,
+			0x36, 0xb4, 0x14, 0xa0,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x10, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x1a, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x24, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2f, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x50, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x50, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x50, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x50, 0x80,
+			0x38, 0xb4, 0x93, 0xd0,
+			0x38, 0xb4, 0xc4, 0xd1,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x5c, 0x13,
+			0x38, 0xb4, 0x04, 0xd7,
+			0x38, 0xb4, 0xbc, 0x5f,
+			0x38, 0xb4, 0x04, 0xd5,
+			0x38, 0xb4, 0xf1, 0xc9,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0xc9, 0x0f,
+			0x38, 0xb4, 0x50, 0xbb,
+			0x38, 0xb4, 0x05, 0xd5,
+			0x38, 0xb4, 0x02, 0xa2,
+			0x38, 0xb4, 0x04, 0xd5,
+			0x38, 0xb4, 0x0f, 0x8c,
+			0x38, 0xb4, 0x00, 0xd5,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x19, 0x15,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x48, 0x15,
+			0x38, 0xb4, 0x70, 0x2f,
+			0x38, 0xb4, 0x2a, 0x80,
+			0x38, 0xb4, 0x73, 0x2f,
+			0x38, 0xb4, 0x6a, 0x15,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x5c, 0x15,
+			0x38, 0xb4, 0x05, 0xd5,
+			0x38, 0xb4, 0x02, 0xa2,
+			0x38, 0xb4, 0x00, 0xd5,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x51, 0x15,
+			0x38, 0xb4, 0xc1, 0xc0,
+			0x38, 0xb4, 0xc0, 0xc0,
+			0x38, 0xb4, 0x5a, 0xd0,
+			0x38, 0xb4, 0xba, 0xd1,
+			0x38, 0xb4, 0x01, 0xd7,
+			0x38, 0xb4, 0x29, 0x25,
+			0x38, 0xb4, 0x2a, 0x02,
+			0x38, 0xb4, 0xa7, 0xd0,
+			0x38, 0xb4, 0xb9, 0xd1,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x0e, 0x08,
+			0x38, 0xb4, 0x01, 0xd7,
+			0x38, 0xb4, 0x8b, 0x40,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x65, 0x0a,
+			0x38, 0xb4, 0x03, 0xf0,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x6b, 0x0a,
+			0x38, 0xb4, 0x01, 0xd7,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x20, 0x09,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x15, 0x09,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x09, 0x09,
+			0x38, 0xb4, 0x8f, 0x22,
+			0x38, 0xb4, 0x38, 0x80,
+			0x38, 0xb4, 0x01, 0x98,
+			0x38, 0xb4, 0x1e, 0xd7,
+			0x38, 0xb4, 0x81, 0x5d,
+			0x38, 0xb4, 0x01, 0xd7,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2a, 0x02,
+			0x36, 0xb4, 0x26, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x24, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x22, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x20, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x06, 0xa0,
+			0x38, 0xb4, 0x0a, 0x02,
+			0x36, 0xb4, 0x04, 0xa0,
+			0x38, 0xb4, 0x5b, 0x15,
+			0x36, 0xb4, 0x02, 0xa0,
+			0x38, 0xb4, 0x42, 0x15,
+			0x36, 0xb4, 0x00, 0xa0,
+			0x38, 0xb4, 0xc7, 0x0f,
+			0x36, 0xb4, 0x08, 0xa0,
+			0x38, 0xb4, 0x00, 0x0f,
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x16, 0xa0,
+			0x38, 0xb4, 0x10, 0x00,
+			0x36, 0xb4, 0x12, 0xa0,
+			0x38, 0xb4, 0x00, 0x00,
+			0x36, 0xb4, 0x14, 0xa0,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x10, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x1d, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2c, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2c, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2c, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2c, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2c, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2c, 0x80,
+			0x38, 0xb4, 0x00, 0xd7,
+			0x38, 0xb4, 0x90, 0x60,
+			0x38, 0xb4, 0xd1, 0x60,
+			0x38, 0xb4, 0x5c, 0xc9,
+			0x38, 0xb4, 0x07, 0xf0,
+			0x38, 0xb4, 0xb1, 0x60,
+			0x38, 0xb4, 0x5a, 0xc9,
+			0x38, 0xb4, 0x04, 0xf0,
+			0x38, 0xb4, 0x56, 0xc9,
+			0x38, 0xb4, 0x02, 0xf0,
+			0x38, 0xb4, 0x4e, 0xc9,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0xcd, 0x00,
+			0x38, 0xb4, 0x00, 0xd7,
+			0x38, 0xb4, 0x90, 0x60,
+			0x38, 0xb4, 0xd1, 0x60,
+			0x38, 0xb4, 0x5c, 0xc9,
+			0x38, 0xb4, 0x07, 0xf0,
+			0x38, 0xb4, 0xb1, 0x60,
+			0x38, 0xb4, 0x5a, 0xc9,
+			0x38, 0xb4, 0x04, 0xf0,
+			0x38, 0xb4, 0x56, 0xc9,
+			0x38, 0xb4, 0x02, 0xf0,
+			0x38, 0xb4, 0x4e, 0xc9,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x2a, 0x02,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x32, 0x01,
+			0x36, 0xb4, 0x8e, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x8c, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x8a, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x88, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x86, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x84, 0xa0,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x82, 0xa0,
+			0x38, 0xb4, 0x2f, 0x01,
+			0x36, 0xb4, 0x80, 0xa0,
+			0x38, 0xb4, 0xcc, 0x00,
+			0x36, 0xb4, 0x90, 0xa0,
+			0x38, 0xb4, 0x03, 0x01,
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x16, 0xa0,
+			0x38, 0xb4, 0x20, 0x00,
+			0x36, 0xb4, 0x12, 0xa0,
+			0x38, 0xb4, 0x00, 0x00,
+			0x36, 0xb4, 0x14, 0xa0,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x10, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x1e, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x26, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2f, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x36, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x36, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x36, 0x80,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x36, 0x80,
+			0x38, 0xb4, 0x07, 0xd1,
+			0x38, 0xb4, 0x42, 0xd0,
+			0x38, 0xb4, 0x04, 0xa4,
+			0x38, 0xb4, 0x00, 0xd7,
+			0x38, 0xb4, 0xf4, 0x5f,
+			0x38, 0xb4, 0x80, 0x82,
+			0x38, 0xb4, 0x00, 0xd7,
+			0x38, 0xb4, 0x65, 0x60,
+			0x38, 0xb4, 0x25, 0xd1,
+			0x38, 0xb4, 0x02, 0xf0,
+			0x38, 0xb4, 0x2b, 0xd1,
+			0x38, 0xb4, 0x40, 0xd0,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x7f, 0x07,
+			0x38, 0xb4, 0xf0, 0x0c,
+			0x38, 0xb4, 0x50, 0x0c,
+			0x38, 0xb4, 0x04, 0xd1,
+			0x38, 0xb4, 0x40, 0xd0,
+			0x38, 0xb4, 0x00, 0xd7,
+			0x38, 0xb4, 0xf4, 0x5f,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x2e, 0x0a,
+			0x38, 0xb4, 0x9b, 0xcb,
+			0x38, 0xb4, 0x10, 0xd1,
+			0x38, 0xb4, 0x40, 0xd0,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0x7b, 0x0b,
+			0x38, 0xb4, 0x00, 0xd7,
+			0x38, 0xb4, 0xf4, 0x5f,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x1b, 0x08,
+			0x38, 0xb4, 0x00, 0x10,
+			0x38, 0xb4, 0xdf, 0x09,
+			0x38, 0xb4, 0x04, 0xd7,
+			0x38, 0xb4, 0xb8, 0x7f,
+			0x38, 0xb4, 0x18, 0xa7,
+			0x38, 0xb4, 0x00, 0x18,
+			0x38, 0xb4, 0x4e, 0x07,
+			0x36, 0xb4, 0x0e, 0xa1,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x0c, 0xa1,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x0a, 0xa1,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x08, 0xa1,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x06, 0xa1,
+			0x38, 0xb4, 0x4d, 0x07,
+			0x36, 0xb4, 0x04, 0xa1,
+			0x38, 0xb4, 0x18, 0x08,
+			0x36, 0xb4, 0x02, 0xa1,
+			0x38, 0xb4, 0x2c, 0x0a,
+			0x36, 0xb4, 0x00, 0xa1,
+			0x38, 0xb4, 0x7e, 0x07,
+			0x36, 0xb4, 0x10, 0xa1,
+			0x38, 0xb4, 0x0f, 0x00,
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x7c, 0xb8,
+			0x38, 0xb4, 0x25, 0x86,
+			0x36, 0xb4, 0x7e, 0xb8,
+			0x38, 0xb4, 0x86, 0xaf,
+			0x38, 0xb4, 0xaf, 0x3d,
+			0x38, 0xb4, 0x89, 0x86,
+			0x38, 0xb4, 0x88, 0xaf,
+			0x38, 0xb4, 0xaf, 0x69,
+			0x38, 0xb4, 0x87, 0x88,
+			0x38, 0xb4, 0x88, 0xaf,
+			0x38, 0xb4, 0xaf, 0x9c,
+			0x38, 0xb4, 0x9c, 0x88,
+			0x38, 0xb4, 0x88, 0xaf,
+			0x38, 0xb4, 0xaf, 0x9c,
+			0x38, 0xb4, 0x9c, 0x88,
+			0x38, 0xb4, 0x86, 0xbf,
+			0x38, 0xb4, 0xd7, 0x49,
+			0x38, 0xb4, 0x40, 0x00,
+			0x38, 0xb4, 0x77, 0x02,
+			0x38, 0xb4, 0xaf, 0x7d,
+			0x38, 0xb4, 0x27, 0x27,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x05, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x08, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0xf3, 0x71,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0xf6, 0x71,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x29, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x2c, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x17, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x1a, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x1d, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x11, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x20, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x14, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x2f, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x23, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x32, 0x72,
+			0x38, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x26, 0x72,
+			0x38, 0xb4, 0xf9, 0xf8,
+			0x38, 0xb4, 0xe0, 0xfa,
+			0x38, 0xb4, 0xb3, 0x85,
+			0x38, 0xb4, 0x02, 0x38,
+			0x38, 0xb4, 0x27, 0xad,
+			0x38, 0xb4, 0xae, 0x02,
+			0x38, 0xb4, 0xaf, 0x03,
+			0x38, 0xb4, 0x30, 0x88,
+			0x38, 0xb4, 0x66, 0x1f,
+			0x38, 0xb4, 0x65, 0xef,
+			0x38, 0xb4, 0xc2, 0xbf,
+			0x38, 0xb4, 0x1a, 0x1f,
+			0x38, 0xb4, 0xf7, 0x96,
+			0x38, 0xb4, 0xee, 0x05,
+			0x38, 0xb4, 0xd2, 0xff,
+			0x38, 0xb4, 0xda, 0x00,
+			0x38, 0xb4, 0x05, 0xf6,
+			0x38, 0xb4, 0xc2, 0xbf,
+			0x38, 0xb4, 0x1a, 0x2f,
+			0x38, 0xb4, 0xf7, 0x96,
+			0x38, 0xb4, 0xee, 0x05,
+			0x38, 0xb4, 0xd2, 0xff,
+			0x38, 0xb4, 0xdb, 0x00,
+			0x38, 0xb4, 0x05, 0xf6,
+			0x38, 0xb4, 0x02, 0xef,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x42, 0x0d,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x42,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x02, 0xef,
+			0x38, 0xb4, 0x03, 0x1b,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x42, 0x0d,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x45,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x02, 0xef,
+			0x38, 0xb4, 0x03, 0x1a,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x42, 0x0d,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x48,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0xc2, 0xbf,
+			0x38, 0xb4, 0x1a, 0x3f,
+			0x38, 0xb4, 0xf7, 0x96,
+			0x38, 0xb4, 0xee, 0x05,
+			0x38, 0xb4, 0xd2, 0xff,
+			0x38, 0xb4, 0xda, 0x00,
+			0x38, 0xb4, 0x05, 0xf6,
+			0x38, 0xb4, 0xc2, 0xbf,
+			0x38, 0xb4, 0x1a, 0x4f,
+			0x38, 0xb4, 0xf7, 0x96,
+			0x38, 0xb4, 0xee, 0x05,
+			0x38, 0xb4, 0xd2, 0xff,
+			0x38, 0xb4, 0xdb, 0x00,
+			0x38, 0xb4, 0x05, 0xf6,
+			0x38, 0xb4, 0x02, 0xef,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x42, 0x0d,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x4b,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x02, 0xef,
+			0x38, 0xb4, 0x03, 0x1b,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x42, 0x0d,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x4e,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x02, 0xef,
+			0x38, 0xb4, 0x03, 0x1a,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x42, 0x0d,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x51,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x56, 0xef,
+			0x38, 0xb4, 0x20, 0xd0,
+			0x38, 0xb4, 0x11, 0x1f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x54,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x57,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x5a,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xef, 0xa0,
+			0x38, 0xb4, 0x48, 0x03,
+			0x38, 0xb4, 0x28, 0x0a,
+			0x38, 0xb4, 0xef, 0x05,
+			0x38, 0xb4, 0x1b, 0x20,
+			0x38, 0xb4, 0xad, 0x01,
+			0x38, 0xb4, 0x35, 0x27,
+			0x38, 0xb4, 0x44, 0x1f,
+			0x38, 0xb4, 0x85, 0xe0,
+			0x38, 0xb4, 0xe1, 0x88,
+			0x38, 0xb4, 0x89, 0x85,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x5d,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x85, 0xe0,
+			0x38, 0xb4, 0xe1, 0x8e,
+			0x38, 0xb4, 0x8f, 0x85,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x60,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x85, 0xe0,
+			0x38, 0xb4, 0xe1, 0x94,
+			0x38, 0xb4, 0x95, 0x85,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x63,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x85, 0xe0,
+			0x38, 0xb4, 0xe1, 0x9a,
+			0x38, 0xb4, 0x9b, 0x85,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x66,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x88, 0xaf,
+			0x38, 0xb4, 0xbf, 0x3c,
+			0x38, 0xb4, 0x3f, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xad, 0x9c,
+			0x38, 0xb4, 0x35, 0x28,
+			0x38, 0xb4, 0x44, 0x1f,
+			0x38, 0xb4, 0x8f, 0xe0,
+			0x38, 0xb4, 0xe1, 0xf8,
+			0x38, 0xb4, 0xf9, 0x8f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x5d,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x8f, 0xe0,
+			0x38, 0xb4, 0xe1, 0xfa,
+			0x38, 0xb4, 0xfb, 0x8f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x60,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x8f, 0xe0,
+			0x38, 0xb4, 0xe1, 0xfc,
+			0x38, 0xb4, 0xfd, 0x8f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x63,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x8f, 0xe0,
+			0x38, 0xb4, 0xe1, 0xfe,
+			0x38, 0xb4, 0xff, 0x8f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x66,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x88, 0xaf,
+			0x38, 0xb4, 0xe1, 0x3c,
+			0x38, 0xb4, 0xa1, 0x85,
+			0x38, 0xb4, 0x21, 0x1b,
+			0x38, 0xb4, 0x37, 0xad,
+			0x38, 0xb4, 0x1f, 0x34,
+			0x38, 0xb4, 0xe0, 0x44,
+			0x38, 0xb4, 0x8a, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x8b,
+			0x38, 0xb4, 0x5d, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xe0, 0x7d,
+			0x38, 0xb4, 0x90, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x91,
+			0x38, 0xb4, 0x60, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xe0, 0x7d,
+			0x38, 0xb4, 0x96, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x97,
+			0x38, 0xb4, 0x63, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xe0, 0x7d,
+			0x38, 0xb4, 0x9c, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x9d,
+			0x38, 0xb4, 0x66, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xae, 0x7d,
+			0x38, 0xb4, 0x1f, 0x40,
+			0x38, 0xb4, 0xe0, 0x44,
+			0x38, 0xb4, 0x8c, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x8d,
+			0x38, 0xb4, 0x5d, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xe0, 0x7d,
+			0x38, 0xb4, 0x92, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x93,
+			0x38, 0xb4, 0x60, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xe0, 0x7d,
+			0x38, 0xb4, 0x98, 0x85,
+			0xff, 0xff, 0xff, 0xff,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x99,
+			0x38, 0xb4, 0x63, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xe0, 0x7d,
+			0x38, 0xb4, 0x9e, 0x85,
+			0x38, 0xb4, 0x85, 0xe1,
+			0x38, 0xb4, 0xbf, 0x9f,
+			0x38, 0xb4, 0x66, 0x88,
+			0x38, 0xb4, 0x6e, 0x02,
+			0x38, 0xb4, 0xae, 0x7d,
+			0x38, 0xb4, 0xe1, 0x0c,
+			0x38, 0xb4, 0xb3, 0x85,
+			0x38, 0xb4, 0x04, 0x39,
+			0x38, 0xb4, 0x2f, 0xac,
+			0x38, 0xb4, 0xee, 0x04,
+			0x38, 0xb4, 0xb3, 0x85,
+			0x38, 0xb4, 0xaf, 0x00,
+			0x38, 0xb4, 0xd9, 0x39,
+			0x38, 0xb4, 0xac, 0x22,
+			0x38, 0xb4, 0xf0, 0xea,
+			0x38, 0xb4, 0xf6, 0xac,
+			0x38, 0xb4, 0xac, 0xf0,
+			0x38, 0xb4, 0xf0, 0xfa,
+			0x38, 0xb4, 0xf8, 0xac,
+			0x38, 0xb4, 0xac, 0xf0,
+			0x38, 0xb4, 0xf0, 0xfc,
+			0x38, 0xb4, 0x00, 0xad,
+			0x38, 0xb4, 0xac, 0xf0,
+			0x38, 0xb4, 0xf0, 0xfe,
+			0x38, 0xb4, 0xf0, 0xac,
+			0x38, 0xb4, 0xac, 0xf0,
+			0x38, 0xb4, 0xf0, 0xf4,
+			0x38, 0xb4, 0xf2, 0xac,
+			0x38, 0xb4, 0xac, 0xf0,
+			0x38, 0xb4, 0xf0, 0xb0,
+			0x38, 0xb4, 0xae, 0xac,
+			0x38, 0xb4, 0xac, 0xf0,
+			0x38, 0xb4, 0xf0, 0xac,
+			0x38, 0xb4, 0xaa, 0xac,
+			0x38, 0xb4, 0x00, 0xa1,
+			0x38, 0xb4, 0xe1, 0x0c,
+			0x38, 0xb4, 0xf7, 0x8f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x84,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x26, 0xaf,
+			0x38, 0xb4, 0xe1, 0xe9,
+			0x38, 0xb4, 0xf6, 0x8f,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x84,
+			0x38, 0xb4, 0x7d, 0x6e,
+			0x38, 0xb4, 0x26, 0xaf,
+			0x38, 0xb4, 0x20, 0xf5,
+			0x38, 0xb4, 0x86, 0xac,
+			0x38, 0xb4, 0x88, 0xbf,
+			0x38, 0xb4, 0x02, 0x3f,
+			0x38, 0xb4, 0x9c, 0x6e,
+			0x38, 0xb4, 0x28, 0xad,
+			0x38, 0xb4, 0xaf, 0x03,
+			0x38, 0xb4, 0x24, 0x33,
+			0x38, 0xb4, 0x38, 0xad,
+			0x38, 0xb4, 0xaf, 0x03,
+			0x38, 0xb4, 0xe6, 0x32,
+			0x38, 0xb4, 0x32, 0xaf,
+			0x38, 0xb4, 0x00, 0xfb,
+			0x36, 0xb4, 0x7c, 0xb8,
+			0x38, 0xb4, 0xf6, 0x8f,
+			0x36, 0xb4, 0x7e, 0xb8,
+			0x38, 0xb4, 0x05, 0x07,
+			0x36, 0xb4, 0x7c, 0xb8,
+			0x38, 0xb4, 0xf8, 0x8f,
+			0x36, 0xb4, 0x7e, 0xb8,
+			0x38, 0xb4, 0xcc, 0x19,
+			0x36, 0xb4, 0x7c, 0xb8,
+			0x38, 0xb4, 0xfa, 0x8f,
+			0x36, 0xb4, 0x7e, 0xb8,
+			0x38, 0xb4, 0xe3, 0x28,
+			0x36, 0xb4, 0x7c, 0xb8,
+			0x38, 0xb4, 0xfc, 0x8f,
+			0x36, 0xb4, 0x7e, 0xb8,
+			0x38, 0xb4, 0x47, 0x10,
+			0x36, 0xb4, 0x7c, 0xb8,
+			0x38, 0xb4, 0xfe, 0x8f,
+			0x36, 0xb4, 0x7e, 0xb8,
+			0x38, 0xb4, 0x45, 0x0a,
+			0x36, 0xb4, 0x5e, 0xb8,
+			0x38, 0xb4, 0x1e, 0x27,
+			0x36, 0xb4, 0x60, 0xb8,
+			0x38, 0xb4, 0x46, 0x38,
+			0x36, 0xb4, 0x62, 0xb8,
+			0x38, 0xb4, 0xe6, 0x26,
+			0x36, 0xb4, 0x64, 0xb8,
+			0x38, 0xb4, 0xe3, 0x32,
+			0x36, 0xb4, 0x86, 0xb8,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x88, 0xb8,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x8a, 0xb8,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x8c, 0xb8,
+			0x38, 0xb4, 0xff, 0xff,
+			0x36, 0xb4, 0x38, 0xb8,
+			0x38, 0xb4, 0x0f, 0x00,
+			0x20, 0xb8, 0x10, 0x00,
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x00, 0x00,
+			0x38, 0xb4, 0x00, 0x00,
+			0x36, 0xb4, 0x2e, 0xb8,
+			0x38, 0xb4, 0x00, 0x00,
+			0x36, 0xb4, 0x24, 0x80,
+			0x38, 0xb4, 0x00, 0x00,
+			0x6c, 0xe8, 0x00, 0xb0,
+			0x20, 0xb8, 0x00, 0x00,
+			0x6c, 0xe8, 0x00, 0xa0,
+			0x36, 0xb4, 0x1e, 0x80,
+			0x38, 0xb4, 0x10, 0x00,
+			0xff, 0xff, 0xff, 0xff};
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd284);
+		ocp_data |= BIT(2) | BIT(6);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xd284, ocp_data);
+
+		data = ram13;
+		len = sizeof(ram13);
+	}
+
+	if (!data)
+		return;
+
+	while (len) {
+		u32 size;
+		int i;
+
+		if (len < 2048)
+			size = len;
+		else
+			size = 2048;
+
+		generic_ocp_write(tp, 0x9A00, 0xff, size, data, MCU_TYPE_USB);
+
+		data += size;
+		len -= size;
+
+		ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xdc6a);
+		ocp_data |= BIT(4);
+		ocp_write_word(tp, MCU_TYPE_USB, 0xdc6a, ocp_data);
+
+		for (i = 0; i < 1000; i++) {
+			if (!(ocp_read_word(tp, MCU_TYPE_USB, 0xdc6a) & BIT(4)))
+				break;
+		}
+
+		if (i == 1000) {
+			dev_err(&tp->intf->dev, "ram code speedup mode fail\n");
+			return;
+		}
+	}
+}
+
+static void r8156_ram_code(struct r8152 *tp, bool power_cut)
 {
 	u16 data;
 
 	if (tp->version == RTL_VER_10) {
-		r8153_pre_ram_code(tp, 0x8024, 0x8600);
+		if (power_cut)
+			rtl_patch_key_set(tp, 0x8024, 0x8600);
+		else
+			r8153_pre_ram_code(tp, 0x8024, 0x8600);
 
 		data = ocp_reg_read(tp, 0xb820);
 		data |= BIT(7);
@@ -9748,9 +11770,15 @@ static void r8156_ram_code(struct r8152 *tp)
 		data &= ~BIT(7);
 		ocp_reg_write(tp, 0xb820, data);
 
-		r8153_post_ram_code(tp, 0x8024);
+		if (power_cut)
+			rtl_patch_key_clear(tp, 0x8024);
+		else
+			r8153_post_ram_code(tp, 0x8024);
 	} else if (tp->version == RTL_VER_11) {
-		r8153_pre_ram_code(tp, 0x8024, 0x8601);
+		if (power_cut)
+			rtl_patch_key_set(tp, 0x8024, 0x8601);
+		else
+			r8153_pre_ram_code(tp, 0x8024, 0x8601);
 
 		data = ocp_reg_read(tp, 0xb820);
 		data |= BIT(7);
@@ -10275,15 +12303,2418 @@ static void r8156_ram_code(struct r8152 *tp)
 		data &= ~BIT(7);
 		ocp_reg_write(tp, 0xb820, data);
 
-		r8153_post_ram_code(tp, 0x8024);
+		if (power_cut)
+			rtl_patch_key_clear(tp, 0x8024);
+		else
+			r8153_post_ram_code(tp, 0x8024);
+	} else if (tp->version == RTL_VER_12) {
+		if (power_cut)
+			rtl_patch_key_set(tp, 0x8024, 0x3700);
+		else
+			r8153_pre_ram_code(tp, 0x8024, 0x3700);
+
+		data = ocp_reg_read(tp, 0xb820);
+		data |= BIT(7);
+		ocp_reg_write(tp, 0xb820, data);
+
+		/* nc_patch */
+		sram_write(tp, 0xA016, 0x0000);
+		sram_write(tp, 0xA012, 0x0000);
+		sram_write(tp, 0xA014, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8010);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8025);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x803a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8044);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x808d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x808d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x808d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd712);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4077);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4159);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6099);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f44);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9201);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1b1a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2425);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3ce5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1afb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1b00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd712);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4077);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4159);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x60b9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2421);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1c17);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1c2c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2425);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3ce5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1c0f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1c13);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd501);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6072);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8401);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa401);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x146e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0b77);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd703);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x665d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x653e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x641f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x62c4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6185);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6066);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x165a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc101);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1945);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fa6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x807d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1945);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2569);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8058);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x807d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc104);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1945);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fa4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x807d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc120);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1945);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd703);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x807d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc140);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1945);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd703);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fbe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x807d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1945);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd703);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fbd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc100);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6018);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x165a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x14f6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd014);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1e3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1356);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fbe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1559);
+		sram_write(tp, 0xA026, 0xffff);
+		sram_write(tp, 0xA024, 0xffff);
+		sram_write(tp, 0xA022, 0xffff);
+		sram_write(tp, 0xA020, 0x1557);
+		sram_write(tp, 0xA006, 0x1677);
+		sram_write(tp, 0xA004, 0x0b75);
+		sram_write(tp, 0xA002, 0x1c17);
+		sram_write(tp, 0xA000, 0x1b04);
+		sram_write(tp, 0xA008, 0x1f00);
+
+		/* nc1_patch */
+
+		/* nc2_patch */
+		sram_write(tp, 0xA016, 0x0020);
+		sram_write(tp, 0xA012, 0x0000);
+		sram_write(tp, 0xA014, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8010);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x817f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x82ab);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x83f8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8444);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8454);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8459);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8465);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb11);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa50c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8310);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4076);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0903);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a4d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb12);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f84);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x60f3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd413);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd410);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb13);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa108);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8108);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa910);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa780);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd14a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd048);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6255);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f74);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6326);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f07);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffe2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fab);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xba08);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9a08);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6535);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd40d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa780);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd14a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd048);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6206);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f47);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8064);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd40e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6073);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4216);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd120);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8504);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb21);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa301);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f9f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8301);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd704);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x40e0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd196);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb22);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa640);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9503);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8910);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8720);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0f14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb23);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fc0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf40);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0cc0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0f80);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xafc0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5dee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb24);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8f1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f6e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa111);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa215);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa401);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa720);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8640);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9503);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0b43);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0b86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb26);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f82);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8111);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8205);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb27);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa104);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8104);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa120);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa0f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd193);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd046);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb28);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb804);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f82);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9804);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb29);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb820);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f65);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9820);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd13d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3444);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8149);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa220);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3444);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8151);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f51);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f63);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd411);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd409);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x82a4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb808);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fa3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9808);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0433);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb15);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa508);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a4d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa301);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f9f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8301);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd704);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x40e0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd115);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd413);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb16);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa640);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9503);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8720);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd17a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0f14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb17);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fc0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf40);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0cc0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0f80);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xafc0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a25);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x61ce);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5db4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb18);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8640);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9503);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa720);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0b43);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffd6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8f1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa131);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa0f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa2d5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa407);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa720);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8310);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa308);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8308);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb19);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8640);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9503);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0b43);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0b86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb1a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f82);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8111);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x82c5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb804);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f82);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9804);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb1b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb820);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f65);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9820);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb1c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb1d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa220);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1f5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd049);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3444);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8221);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f51);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa504);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x82a4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb808);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fa3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9808);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f84);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd14a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd048);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa780);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f94);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6208);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f27);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffe9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa406);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa220);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3444);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x827d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f51);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb2f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f63);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd411);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd409);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x82a4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8406);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb808);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fa3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9808);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0433);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb30);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8380);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9308);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb301);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb32);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd408);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd141);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd043);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd704);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ccc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4c81);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x609e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa108);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8108);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa203);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8120);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8a0f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa111);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa140);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8140);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd17a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8101);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8201);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa104);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8104);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa120);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa0f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd193);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd047);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd13d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf024);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa280);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8406);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4121);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x60f3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa280);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb33);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa710);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb820);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd71f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f65);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9820);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb34);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6853);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8284);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb35);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd407);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8204);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa280);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd704);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4215);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa304);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1c3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd043);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8304);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4109);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf01e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb36);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd412);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6309);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42c7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8280);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd14a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd048);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a7d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcc55);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa2a4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6041);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd13d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f71);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb38);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8224);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa288);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x800a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6041);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd415);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a37);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd13d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd04a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb39);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa2a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6041);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd17a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd047);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fb4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0560);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa111);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd3f5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd219);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa215);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd30e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd21a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x63e9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f65);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f36);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c35);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8004);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c35);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8001);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4098);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9401);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd103);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb401);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c27);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa108);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c35);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8108);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8110);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8294);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa202);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0bdb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd39c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd210);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd39c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd210);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5fa5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x29b5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x840e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd708);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f4a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1014);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c31);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd709);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7fa4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x901f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c23);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb43);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa508);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3699);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x844a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa504);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa2a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2109);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ea);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ea);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcb90);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0cf0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0ca0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x06db);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd1ff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd052);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa508);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8718);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa00a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa190);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa2a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa404);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0cf0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c50);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x09ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a5e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd704);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2e70);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x06da);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f55);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa90c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0645);
+		sram_write(tp, 0xA10E, 0x0644);
+		sram_write(tp, 0xA10C, 0x09e9);
+		sram_write(tp, 0xA10A, 0x06da);
+		sram_write(tp, 0xA108, 0x05e1);
+		sram_write(tp, 0xA106, 0x0be4);
+		sram_write(tp, 0xA104, 0x0435);
+		sram_write(tp, 0xA102, 0x0141);
+		sram_write(tp, 0xA100, 0x026d);
+		sram_write(tp, 0xA110, 0x00ff);
+
+		/* uc2 */
+		sram_write(tp, 0xb87c, 0x85fe);
+		sram_write(tp, 0xb87e, 0xaf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x16af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8699);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe5af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x86f9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf87);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7aaf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x883a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x58af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b6c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd48b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7c02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8644);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2c00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x503c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffd6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac27);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x18e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x82fe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad28);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0cd4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b84);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0286);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x442c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x003c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac27);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x06ee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8299);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x01ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x04ee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8299);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x23dc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf9fa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcefa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfbef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x79fb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc4bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b76);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6dac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2804);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd203);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd201);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbdd8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x19d9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef94);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6d78);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x648a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbdd8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x19d9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef94);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6d78);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x72cd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac50);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x643a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x019f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe4ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4678);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd0ff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x97ff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfec6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfefd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x041f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x771f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x221c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x450d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x481f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7f04);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a94);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae08);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a94);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac7f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03d7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0100);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef46);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1c45);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef69);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef57);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef74);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0272);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe8a7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d1a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x941b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x979e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x072d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0100);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a64);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef76);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef97);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d98);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd400);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xff1d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x941a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x89cf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a75);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf74);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf9bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b79);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6da1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0005);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa0ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x80a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf26);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9aac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x284d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe08f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x10c0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe08f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfe10);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1b08);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x04c8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf40);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67c8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8c02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc4bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6def);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x74e0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x830c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad20);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x74ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xccef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x971b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x76ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae13);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef69);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef30);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1b32);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc4ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x46e4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe58f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfce7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xcc10);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x11ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb8d1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf40);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4fbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ec4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8f02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef74);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe083);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0cad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2003);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0274);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaccc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef97);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1b76);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad5f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x04ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x69ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3111);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaed1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0287);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x80af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2293);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf8f9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfafb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef59);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe080);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x13ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x252f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2802);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef64);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f44);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb91b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x64ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f1d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd688);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2bd7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x882e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0274);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x73ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5008);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x737c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0287);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd0bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x882b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0273);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x73e0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x824c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf621);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe482);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4cbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8834);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0273);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7cef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x95ff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfefd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfc04);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf8f9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfafb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef79);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x737c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f22);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac32);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x31ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x12bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8822);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ed6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fba);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f33);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac3c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x13bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8837);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x96d8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x19d9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1616);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x13ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xdf12);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaecc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7373);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef97);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfffe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfdfc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0466);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x88f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac8a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x92ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbadd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac6c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeeac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6cff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x99ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0030);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd4c3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0000);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00b4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xecee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8298);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1412);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf8bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b5d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6d58);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fb8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2901);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe58f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb8a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0049);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef47);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe483);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8303);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbfc2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f1a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x95f7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffd2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00d8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf605);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f11);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef60);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf728);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf628);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c64);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef46);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0289);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf89);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x96a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0149);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef47);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe483);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x04e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8305);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbfc2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f1a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x95f7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffd2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00d8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf605);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f11);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef60);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf729);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf629);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c64);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef46);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0289);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf89);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x96a0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0249);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef47);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe483);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x06e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8307);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbfc2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5f1a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x95f7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffd2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00d8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf605);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f11);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef60);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c6d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf72a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf62a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0c64);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef46);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6602);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0289);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x9902);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3920);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf89);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x96ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x47e4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8308);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe583);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x09bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc25f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a95);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeeff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd200);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd8f6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x051f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x11ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x60bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b30);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ebf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b33);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6df7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2bbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b33);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ef6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2bbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b33);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4e0c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x64ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x46bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b69);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4e02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8999);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0239);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x20af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8996);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf39);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1ef8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf9fa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe08f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb838);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x201f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x66ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x65bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc21f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a96);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeeff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd200);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xdaf6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc22f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a96);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeeff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd200);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xdbf6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x021f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x110d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b3c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x021b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x031f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x110d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b36);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x021a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x031f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x110d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b39);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ebf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc23f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a96);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeeff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd200);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xdaf6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc24f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a96);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeeff);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd200);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xdbf6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x05ef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x021f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x110d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b45);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x021b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x031f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x110d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b3f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x021a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x031f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x110d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x42bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b42);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4eef);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x56d0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x201f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x11bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ebf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ebf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b4b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ee1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8578);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef03);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x480a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2805);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xef20);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1b01);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad27);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3f1f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x44e0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8560);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe185);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x61bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b51);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ee0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8566);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe185);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b54);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ee0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x856c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe185);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6dbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b57);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ee0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8572);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe185);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x73bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b5a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x026c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4ee1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fb8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5900);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf728);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe58f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb8af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8b2c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe185);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x791b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x21ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x373e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f44);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x62e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8563);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x68e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8569);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6ee1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x856f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x74e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8575);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5a02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb859);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00f7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x28e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fb8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae4a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1f44);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x64e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8565);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6ae1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x856b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x70e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8571);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe085);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x76e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8577);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5a02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6c4e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb859);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00f7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x28e5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8fb8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae0c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb839);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x04ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2f04);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xee8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfefd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfc04);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8efc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac8c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfaf0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xacf8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf6f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfef0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xacfc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf4f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xacf2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xacb0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaef0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xacac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaaf0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xacee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0b0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x24f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb0a4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0b1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x24f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb1a4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xee8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd400);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3976);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x66ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xeabb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa430);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e50);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e53);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e56);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e59);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e5c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e5f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e62);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6e65);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd9ac);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x70f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac6a);
+		sram_write(tp, 0xb85e, 0x23b7);
+		sram_write(tp, 0xb860, 0x74db);
+		sram_write(tp, 0xb862, 0x268c);
+		sram_write(tp, 0xb864, 0x3FE5);
+		sram_write(tp, 0xb886, 0x2250);
+		sram_write(tp, 0xb888, 0x140e);
+		sram_write(tp, 0xb88a, 0x3696);
+		sram_write(tp, 0xb88c, 0x3973);
+		sram_write(tp, 0xb838, 0x00ff);
+
+		data = ocp_reg_read(tp, 0xb820);
+		data &= ~BIT(7);
+		ocp_reg_write(tp, 0xb820, data);
+
+		/* uc */
+		sram_write(tp, 0x8464, 0xaf84);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7caf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8485);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x13af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x851e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb9af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8684);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf87);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x01af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8701);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xac38);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x38bb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf38);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4618);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0a02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54b7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54c0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd400);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0fbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8507);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8504);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6759);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3008);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54c0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae06);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0d02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54b7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa183);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x15a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae10);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x59f0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa180);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x16bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8501);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x381b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae0b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xffbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x84fe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x17bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x84fe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0254);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb7bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x84fb);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0254);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb7ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x09a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x5006);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf84);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfb02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54c0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf04);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4700);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad34);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfdad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0670);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae14);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf0a6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00b8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbd32);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x30bd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x30aa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbd2c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xccbd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2ca1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x0705);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xec80);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf40);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf7af);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x40f5);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd101);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54c0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd10f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6abf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddd1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85aa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4802);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4d6a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfbdd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfcdd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfddd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb602);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfedd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54b7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54b7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf3c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x2066);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb800);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb8bd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x30ee);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbd2c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb8bd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7040);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbd86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc8bd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8640);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbd88);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xc8bd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8802);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1929);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa202);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x03a2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x032e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd10f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf7bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf9bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb602);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae2c);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd100);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfbbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfdbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffe);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb602);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7e02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa100);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x02ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x25a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x041d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf1bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8675);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff2);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7802);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf3bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x867b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48ae);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x29a1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x070b);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xae24);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8102);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad28);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1be1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff4);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7502);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xe18f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xf5bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8678);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x48e1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf86);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x7b02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf09);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8420);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbc32);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x20bc);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x3e76);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbc08);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfda6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x1a00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb64e);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd101);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa402);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54c0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xd10f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaa02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f48);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024d);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x6abf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85ad);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b0);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff8);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b3);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ff9);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddbf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85b6);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x67bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8ffa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xddd1);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x00bf);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x85aa);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x024f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4802);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4d6a);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xad02);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfbdd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb002);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfcdd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb302);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfddd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xb602);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x4f67);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf8f);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xfedd);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xbf85);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xa702);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x54b7);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0xaf00);
+		ocp_reg_write(tp, OCP_SRAM_DATA, 0x8800);
+		sram_write(tp, 0xb818, 0x38b8);
+		sram_write(tp, 0xb81a, 0x0444);
+		sram_write(tp, 0xb81c, 0x40ee);
+		sram_write(tp, 0xb81e, 0x3C1A);
+		sram_write(tp, 0xb850, 0x0981);
+		sram_write(tp, 0xb852, 0x0085);
+		sram_write(tp, 0xb878, 0xffff);
+		sram_write(tp, 0xb884, 0xffff);
+		sram_write(tp, 0xb832, 0x003f);
+
+		if (power_cut)
+			rtl_patch_key_clear(tp, 0x8024);
+		else
+			r8153_post_ram_code(tp, 0x8024);
+	} else {
+		rtl_ram_code_speed_up(tp);
 	}
+
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_OCP_GPHY_BASE, tp->ocp_base);
 }
 
-static void r8156_hw_phy_cfg2(struct r8152 *tp)
+static void r8156_hw_phy_cfg(struct r8152 *tp)
 {
 	bool pcut_entr;
 	u32 ocp_data;
 	u16 data;
+
+	r8156_patch_code(tp);
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_MISC_0);
 	pcut_entr = (ocp_data & PCUT_STATUS) ? true : false;
@@ -10294,31 +14725,20 @@ static void r8156_hw_phy_cfg2(struct r8152 *tp)
 		data = r8153_phy_status(tp, PHY_STAT_EXT_INIT);
 		WARN_ON_ONCE(data != PHY_STAT_EXT_INIT);
 
-		r8156_ram_code(tp);
+		r8156_ram_code(tp, true);
 
 		data = ocp_reg_read(tp, 0xa468);
-		data &= ~(BIT(3) | BIT(0));
+		data &= ~(BIT(3) | BIT(1));
 		ocp_reg_write(tp, 0xa468, data);
 	} else {
-		r8156_patch_code(tp);
-
-		if (r8153_patch_request(tp, true)) {
-			netif_err(tp, drv, tp->netdev,
-				  "patch request error\n");
-			return;
-		}
-
-		r8156_ram_code(tp);
-
-		r8153_patch_request(tp, false);
-
-		/* disable ALDPS before updating the PHY parameters */
-		r8153_aldps_en(tp, false);
-
-		/* disable EEE before updating the PHY parameters */
-		r8153_eee_en(tp, false);
-		ocp_reg_write(tp, OCP_EEE_ADV, 0);
+		r8156_ram_code(tp, false);
 	}
+
+	/* disable ALDPS before updating the PHY parameters */
+	r8153_aldps_en(tp, false);
+
+	/* disable EEE before updating the PHY parameters */
+	rtl_eee_enable(tp, false);
 
 	data = r8153_phy_status(tp, PHY_STAT_LAN_ON);
 	WARN_ON_ONCE(data != PHY_STAT_LAN_ON);
@@ -10432,9 +14852,9 @@ static void r8156_hw_phy_cfg2(struct r8152 *tp)
 		ocp_reg_write(tp, 0xbd2c, data);
 		break;
 	case RTL_VER_11:
-		data = ocp_reg_read(tp, 0xad4e);
-		data |= BIT(4);
-		ocp_reg_write(tp, 0xad4e, data);
+//		data = ocp_reg_read(tp, 0xad4e);
+//		data |= BIT(4);
+//		ocp_reg_write(tp, 0xad4e, data);
 		data = ocp_reg_read(tp, 0xad16);
 		data |= 0x3ff;
 		ocp_reg_write(tp, 0xad16, data);
@@ -10464,12 +14884,21 @@ static void r8156_hw_phy_cfg2(struct r8152 *tp)
 		data |= BIT(1);
 		ocp_reg_write(tp, 0xac5e, data);
 		ocp_reg_write(tp, 0xad4c, 0x00a8);
-		data = ocp_reg_read(tp, 0xac5c);
 		ocp_reg_write(tp, 0xac5c, 0x01ff);
 		data = ocp_reg_read(tp, 0xac8a);
 		data &= ~0xf0;
 		data |= BIT(4) | BIT(5);
 		ocp_reg_write(tp, 0xac8a, data);
+		ocp_reg_write(tp, 0xb87c, 0x8157);
+		data = ocp_reg_read(tp, 0xb87e);
+		data &= ~0xff00;
+		data |= 0x0500;
+		ocp_reg_write(tp, 0xb87e, data);
+		ocp_reg_write(tp, 0xb87c, 0x8159);
+		data = ocp_reg_read(tp, 0xb87e);
+		data &= ~0xff00;
+		data |= 0x0700;
+		ocp_reg_write(tp, 0xb87e, data);
 		ocp_reg_write(tp, 0xb87c, 0x80a2);
 		ocp_reg_write(tp, 0xb87e, 0x0153);
 		ocp_reg_write(tp, 0xb87c, 0x809c);
@@ -10640,34 +15069,542 @@ static void r8156_hw_phy_cfg2(struct r8152 *tp)
 		data = ocp_reg_read(tp, 0xa86a);
 		data &= ~BIT(0);
 		ocp_reg_write(tp, 0xa86a, data);
+
+		/* MDI SWAP */
+		if ((ocp_read_word(tp, MCU_TYPE_USB, 0xdb42) & BIT(5)) &&
+		    (ocp_reg_read(tp, 0xd068) & BIT(1))) {
+			u16 swap_a, swap_b;
+
+			data = ocp_reg_read(tp, 0xd068);
+			data &= ~0x1f;
+			data |= 0;
+			ocp_reg_write(tp, 0xd068, data);
+			swap_a = ocp_reg_read(tp, 0xd06a);
+			data &= ~0x1f;
+			data |= 0x18;
+			ocp_reg_write(tp, 0xd068, data);
+			swap_b = ocp_reg_read(tp, 0xd06a);
+			data &= ~0x1f;
+			data |= 0;
+			ocp_reg_write(tp, 0xd068, data);
+			ocp_reg_write(tp, 0xd06a,
+				      (swap_a & ~0x7ff) | (swap_b & 0x7ff));
+			data &= ~0x1f;
+			data |= 0x18;
+			ocp_reg_write(tp, 0xd068, data);
+			ocp_reg_write(tp, 0xd06a,
+				      (swap_b & ~0x7ff) | (swap_a & 0x7ff));
+			data &= ~0x1f;
+			data |= 0x08;
+			ocp_reg_write(tp, 0xd068, data);
+			swap_a = ocp_reg_read(tp, 0xd06a);
+			data &= ~0x1f;
+			data |= 0x10;
+			ocp_reg_write(tp, 0xd068, data);
+			swap_b = ocp_reg_read(tp, 0xd06a);
+			data &= ~0x1f;
+			data |= 0x08;
+			ocp_reg_write(tp, 0xd068, data);
+			ocp_reg_write(tp, 0xd06a,
+				      (swap_a & ~0x7ff) | (swap_b & 0x7ff));
+			data &= ~0x1f;
+			data |= 0x10;
+			ocp_reg_write(tp, 0xd068, data);
+			ocp_reg_write(tp, 0xd06a,
+				      (swap_b & ~0x7ff) | (swap_a & 0x7ff));
+			swap_a = ocp_reg_read(tp, 0xbd5a);
+			swap_b = ocp_reg_read(tp, 0xbd5c);
+			ocp_reg_write(tp, 0xbd5a, (swap_a & ~0x1f1f) |
+				      ((swap_b & 0x1f) << 8) |
+				      ((swap_b >> 8) & 0x1f));
+			ocp_reg_write(tp, 0xbd5c, (swap_b & ~0x1f1f) |
+				      ((swap_a & 0x1f) << 8) |
+				      ((swap_a >> 8) & 0x1f));
+			swap_a = ocp_reg_read(tp, 0xbc18);
+			swap_b = ocp_reg_read(tp, 0xbc1a);
+			ocp_reg_write(tp, 0xbc18, (swap_a & ~0x1f1f) |
+				      ((swap_b & 0x1f) << 8) |
+				      ((swap_b >> 8) & 0x1f));
+			ocp_reg_write(tp, 0xbc1a, (swap_b & ~0x1f1f) |
+				      ((swap_a & 0x1f) << 8) |
+				      ((swap_a >> 8) & 0x1f));
+		}
 		break;
 	default:
 		break;
 	}
 
-	if (!pcut_entr) {
-		data = ocp_reg_read(tp, 0xa428);
-		data &= ~BIT(9);
-		ocp_reg_write(tp, 0xa428, data);
-		data = ocp_reg_read(tp, 0xa5ea);
-		data &= ~BIT(0);
-		ocp_reg_write(tp, 0xa5ea, data);
-		tp->ups_info.lite_mode = 0;
+	data = ocp_reg_read(tp, 0xa428);
+	data &= ~BIT(9);
+	ocp_reg_write(tp, 0xa428, data);
+	data = ocp_reg_read(tp, 0xa5ea);
+	data &= ~BIT(0);
+	ocp_reg_write(tp, 0xa5ea, data);
+	tp->ups_info.lite_mode = 0;
 
-		if (tp->eee_en) {
-			r8156_eee_en(tp, true);
-			ocp_reg_write(tp, OCP_EEE_ADV, tp->eee_adv);
-		}
+	if (tp->eee_en)
+		rtl_eee_enable(tp, true);
 
-		r8153_aldps_en(tp, true);
-		r8152b_enable_fc(tp);
-		r8153_u2p3en(tp, true);
+	r8153_aldps_en(tp, true);
+	r8152b_enable_fc(tp);
+	r8153_u2p3en(tp, true);
 
-		set_bit(PHY_RESET, &tp->flags);
-	}
+	set_bit(PHY_RESET, &tp->flags);
 }
 
-static void r8156_hw_phy_cfg(struct r8152 *tp)
+static void r8156b_hw_phy_cfg(struct r8152 *tp)
+{
+	bool pcut_entr;
+	u32 ocp_data;
+	u16 data;
+
+	r8156_patch_code(tp);
+
+	if (tp->version == RTL_VER_12) {
+		ocp_reg_write(tp, 0xbf86, 0x9000);
+		data = ocp_reg_read(tp, 0xc402);
+		data |= BIT(10);
+		ocp_reg_write(tp, 0xc402, data);
+		data &= ~BIT(10);
+		ocp_reg_write(tp, 0xc402, data);
+		ocp_reg_write(tp, 0xbd86, 0x1010);
+		ocp_reg_write(tp, 0xbd88, 0x1010);
+		data = ocp_reg_read(tp, 0xbd4e);
+		data &= ~(BIT(10) | BIT(11));
+		data |= BIT(11);
+		ocp_reg_write(tp, 0xbd4e, data);
+		data = ocp_reg_read(tp, 0xbf46);
+		data &= ~0xf00;
+		data |= 0x700;
+		ocp_reg_write(tp, 0xbf46, data);
+	}
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_MISC_0);
+	pcut_entr = (ocp_data & PCUT_STATUS) ? true : false;
+	if (pcut_entr) {
+		ocp_data &= ~PCUT_STATUS;
+		ocp_write_word(tp, MCU_TYPE_USB, USB_MISC_0, ocp_data);
+
+		data = r8153_phy_status(tp, PHY_STAT_EXT_INIT);
+//		switch (data) {
+//		case PHY_STAT_PWRDN:
+//		case PHY_STAT_EXT_INIT:
+//			break;
+//		default:
+//			break;
+//		}
+
+		r8156_ram_code(tp, true);
+
+		data = ocp_reg_read(tp, 0xa466);
+		data &= ~BIT(0);
+		ocp_reg_write(tp, 0xa466, data);
+
+		data = ocp_reg_read(tp, 0xa468);
+		data &= ~(BIT(3) | BIT(1));
+		ocp_reg_write(tp, 0xa468, data);
+
+		data = r8152_mdio_read(tp, MII_BMCR);
+		if (data & BMCR_PDOWN) {
+			data &= ~BMCR_PDOWN;
+			r8152_mdio_write(tp, MII_BMCR, data);
+		}
+	} else {
+		r8156_ram_code(tp, false);
+	}
+
+	/* disable ALDPS before updating the PHY parameters */
+	r8153_aldps_en(tp, false);
+
+	/* disable EEE before updating the PHY parameters */
+	rtl_eee_enable(tp, false);
+
+	data = r8153_phy_status(tp, PHY_STAT_LAN_ON);
+	WARN_ON_ONCE(data != PHY_STAT_LAN_ON);
+
+//	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_PHY_PWR);
+//	ocp_data |= PFM_PWM_SWITCH;
+//	ocp_write_word(tp, MCU_TYPE_PLA, PLA_PHY_PWR, ocp_data);
+
+	switch (tp->version) {
+	case RTL_VER_12:
+//		ocp_reg_write(tp, 0xbf86, 0x9000);
+//		data = ocp_reg_read(tp, 0xc402);
+//		data |= BIT(10);
+//		ocp_reg_write(tp, 0xc402, data);
+//		data &= ~BIT(10);
+//		ocp_reg_write(tp, 0xc402, data);
+//		ocp_reg_write(tp, 0xbd86, 0x1010);
+//		ocp_reg_write(tp, 0xbd88, 0x1010);
+//		data = ocp_reg_read(tp, 0xbd4e);
+//		data &= ~(BIT(10) | BIT(11));
+//		data |= BIT(11);
+//		ocp_reg_write(tp, 0xbd4e, data);
+//		data = ocp_reg_read(tp, 0xbf46);
+//		data &= ~0xf00;
+//		data |= 0x700;
+//		ocp_reg_write(tp, 0xbf46, data);
+
+		data = ocp_reg_read(tp, 0xbc08);
+		data |= BIT(3) | BIT(2);
+		ocp_reg_write(tp, 0xbc08, data);
+
+		data = sram_read(tp, 0x8fff);
+		data &= ~0xff00;
+		data |= 0x0400;
+		sram_write(tp, 0x8fff, data);
+
+		data = ocp_reg_read(tp, 0xacda);
+		data |= 0xff00;
+		ocp_reg_write(tp, 0xacda, data);
+		data = ocp_reg_read(tp, 0xacde);
+		data |= 0xf000;
+		ocp_reg_write(tp, 0xacde, data);
+		ocp_reg_write(tp, 0xac8c, 0x0ffc);
+		ocp_reg_write(tp, 0xac46, 0xb7b4);
+		ocp_reg_write(tp, 0xac50, 0x0fbc);
+		ocp_reg_write(tp, 0xac3c, 0x9240);
+		ocp_reg_write(tp, 0xac4e, 0x0db4);
+		ocp_reg_write(tp, 0xacc6, 0x0707);
+		ocp_reg_write(tp, 0xacc8, 0xa0d3);
+		ocp_reg_write(tp, 0xad08, 0x0007);
+
+		ocp_reg_write(tp, 0xb87c, 0x8560);
+		ocp_reg_write(tp, 0xb87e, 0x19cc);
+		ocp_reg_write(tp, 0xb87c, 0x8562);
+		ocp_reg_write(tp, 0xb87e, 0x19cc);
+		ocp_reg_write(tp, 0xb87c, 0x8564);
+		ocp_reg_write(tp, 0xb87e, 0x19cc);
+		ocp_reg_write(tp, 0xb87c, 0x8566);
+		ocp_reg_write(tp, 0xb87e, 0x147d);
+		ocp_reg_write(tp, 0xb87c, 0x8568);
+		ocp_reg_write(tp, 0xb87e, 0x147d);
+		ocp_reg_write(tp, 0xb87c, 0x856a);
+		ocp_reg_write(tp, 0xb87e, 0x147d);
+		ocp_reg_write(tp, 0xb87c, 0x8ffe);
+		ocp_reg_write(tp, 0xb87e, 0x0907);
+		ocp_reg_write(tp, 0xb87c, 0x80d6);
+		ocp_reg_write(tp, 0xb87e, 0x2801);
+		ocp_reg_write(tp, 0xb87c, 0x80f2);
+		ocp_reg_write(tp, 0xb87e, 0x2801);
+		ocp_reg_write(tp, 0xb87c, 0x80f4);
+		ocp_reg_write(tp, 0xb87e, 0x6077);
+		ocp_reg_write(tp, 0xb506, 0x01e7);
+
+		ocp_reg_write(tp, 0xb87c, 0x8013);
+		ocp_reg_write(tp, 0xb87e, 0x0700);
+		ocp_reg_write(tp, 0xb87c, 0x8fb9);
+		ocp_reg_write(tp, 0xb87e, 0x2801);
+		ocp_reg_write(tp, 0xb87c, 0x8fba);
+		ocp_reg_write(tp, 0xb87e, 0x0100);
+		ocp_reg_write(tp, 0xb87c, 0x8fbc);
+		ocp_reg_write(tp, 0xb87e, 0x1900);
+		ocp_reg_write(tp, 0xb87c, 0x8fbe);
+		ocp_reg_write(tp, 0xb87e, 0xe100);
+		ocp_reg_write(tp, 0xb87c, 0x8fc0);
+		ocp_reg_write(tp, 0xb87e, 0x0800);
+		ocp_reg_write(tp, 0xb87c, 0x8fc2);
+		ocp_reg_write(tp, 0xb87e, 0xe500);
+		ocp_reg_write(tp, 0xb87c, 0x8fc4);
+		ocp_reg_write(tp, 0xb87e, 0x0f00);
+		ocp_reg_write(tp, 0xb87c, 0x8fc6);
+		ocp_reg_write(tp, 0xb87e, 0xf100);
+		ocp_reg_write(tp, 0xb87c, 0x8fc8);
+		ocp_reg_write(tp, 0xb87e, 0x0400);
+		ocp_reg_write(tp, 0xb87c, 0x8fca);
+		ocp_reg_write(tp, 0xb87e, 0xf300);
+		ocp_reg_write(tp, 0xb87c, 0x8fcc);
+		ocp_reg_write(tp, 0xb87e, 0xfd00);
+		ocp_reg_write(tp, 0xb87c, 0x8fce);
+		ocp_reg_write(tp, 0xb87e, 0xff00);
+		ocp_reg_write(tp, 0xb87c, 0x8fd0);
+		ocp_reg_write(tp, 0xb87e, 0xfb00);
+		ocp_reg_write(tp, 0xb87c, 0x8fd2);
+		ocp_reg_write(tp, 0xb87e, 0x0100);
+		ocp_reg_write(tp, 0xb87c, 0x8fd4);
+		ocp_reg_write(tp, 0xb87e, 0xf400);
+		ocp_reg_write(tp, 0xb87c, 0x8fd6);
+		ocp_reg_write(tp, 0xb87e, 0xff00);
+		ocp_reg_write(tp, 0xb87c, 0x8fd8);
+		ocp_reg_write(tp, 0xb87e, 0xf600);
+
+		ocp_data = ocp_read_byte(tp, MCU_TYPE_PLA, 0xe952);
+		ocp_data |= BIT(2) | BIT(1);
+		ocp_write_byte(tp, MCU_TYPE_PLA, 0xe952, ocp_data);
+		ocp_reg_write(tp, 0xb87c, 0x813d);
+		ocp_reg_write(tp, 0xb87e, 0x390e);
+		ocp_reg_write(tp, 0xb87c, 0x814f);
+		ocp_reg_write(tp, 0xb87e, 0x790e);
+		ocp_reg_write(tp, 0xb87c, 0x80b0);
+		ocp_reg_write(tp, 0xb87e, 0x0f31);
+		data = ocp_reg_read(tp, 0xbf4c);
+		data |= BIT(1);
+		ocp_reg_write(tp, 0xbf4c, data);
+		data = ocp_reg_read(tp, 0xbcca);
+		data |= BIT(9) | BIT(8);
+		ocp_reg_write(tp, 0xbcca, data);
+		ocp_reg_write(tp, 0xb87c, 0x8141);
+		ocp_reg_write(tp, 0xb87e, 0x320e);
+		ocp_reg_write(tp, 0xb87c, 0x8153);
+		ocp_reg_write(tp, 0xb87e, 0x720e);
+		ocp_reg_write(tp, 0xb87c, 0x8529);
+		ocp_reg_write(tp, 0xb87e, 0x050e);
+		data = ocp_reg_read(tp, OCP_EEE_CFG);
+		data &= ~CTAP_SHORT_EN;
+		ocp_reg_write(tp, OCP_EEE_CFG, data);
+
+		sram_write(tp, 0x816c, 0xc4a0);
+		sram_write(tp, 0x8170, 0xc4a0);
+		sram_write(tp, 0x8174, 0x04a0);
+		sram_write(tp, 0x8178, 0x04a0);
+		sram_write(tp, 0x817c, 0x0719);
+		sram_write(tp, 0x8ff4, 0x0400);
+		sram_write(tp, 0x8ff1, 0x0404);
+
+		ocp_reg_write(tp, 0xbf4a, 0x001b);
+		ocp_reg_write(tp, 0xb87c, 0x8033);
+		ocp_reg_write(tp, 0xb87e, 0x7c13);
+		ocp_reg_write(tp, 0xb87c, 0x8037);
+		ocp_reg_write(tp, 0xb87e, 0x7c13);
+		ocp_reg_write(tp, 0xb87c, 0x803b);
+		ocp_reg_write(tp, 0xb87e, 0xfc32);
+		ocp_reg_write(tp, 0xb87c, 0x803f);
+		ocp_reg_write(tp, 0xb87e, 0x7c13);
+		ocp_reg_write(tp, 0xb87c, 0x8043);
+		ocp_reg_write(tp, 0xb87e, 0x7c13);
+		ocp_reg_write(tp, 0xb87c, 0x8047);
+		ocp_reg_write(tp, 0xb87e, 0x7c13);
+
+		ocp_reg_write(tp, 0xb87c, 0x8145);
+		ocp_reg_write(tp, 0xb87e, 0x370e);
+		ocp_reg_write(tp, 0xb87c, 0x8157);
+		ocp_reg_write(tp, 0xb87e, 0x770e);
+		ocp_reg_write(tp, 0xb87c, 0x8169);
+		ocp_reg_write(tp, 0xb87e, 0x0d0a);
+		ocp_reg_write(tp, 0xb87c, 0x817b);
+		ocp_reg_write(tp, 0xb87e, 0x1d0a);
+
+		data = sram_read(tp, 0x8217);
+		data &= ~0xff00;
+		data |= 0x5000;
+		sram_write(tp, 0x8217, data);
+		data = sram_read(tp, 0x821a);
+		data &= ~0xff00;
+		data |= 0x5000;
+		sram_write(tp, 0x821a, data);
+		sram_write(tp, 0x80da, 0x0403);
+		data = sram_read(tp, 0x80dc);
+		data &= ~0xff00;
+		data |= 0x1000;
+		sram_write(tp, 0x80dc, data);
+		sram_write(tp, 0x80b3, 0x0384);
+		sram_write(tp, 0x80b7, 0x2007);
+		data = sram_read(tp, 0x80ba);
+		data &= ~0xff00;
+		data |= 0x6c00;
+		sram_write(tp, 0x80ba, data);
+		sram_write(tp, 0x80b5, 0xf009);
+		data = sram_read(tp, 0x80bd);
+		data &= ~0xff00;
+		data |= 0x9f00;
+		sram_write(tp, 0x80bd, data);
+		sram_write(tp, 0x80c7, 0xf083);
+		sram_write(tp, 0x80dd, 0x03f0);
+		data = sram_read(tp, 0x80df);
+		data &= ~0xff00;
+		data |= 0x1000;
+		sram_write(tp, 0x80df, data);
+		sram_write(tp, 0x80cb, 0x2007);
+		data = sram_read(tp, 0x80ce);
+		data &= ~0xff00;
+		data |= 0x6c00;
+		sram_write(tp, 0x80ce, data);
+		sram_write(tp, 0x80c9, 0x8009);
+		data = sram_read(tp, 0x80d1);
+		data &= ~0xff00;
+		data |= 0x8000;
+		sram_write(tp, 0x80d1, data);
+		sram_write(tp, 0x80a3, 0x200a);
+		sram_write(tp, 0x80a5, 0xf0ad);
+		sram_write(tp, 0x809f, 0x6073);
+		sram_write(tp, 0x80a1, 0x000b);
+		data = sram_read(tp, 0x80a9);
+		data &= ~0xff00;
+		data |= 0xc000;
+		sram_write(tp, 0x80a9, data);
+
+		if (r8153_patch_request(tp, true)) {
+			netif_err(tp, drv, tp->netdev,
+				  "patch request error\n");
+			return;
+		}
+		data = ocp_reg_read(tp, 0xb896);
+		data &= ~BIT(0);
+		ocp_reg_write(tp, 0xb896, data);
+		data = ocp_reg_read(tp, 0xb892);
+		data &= ~0xff00;
+		ocp_reg_write(tp, 0xb892, data);
+		ocp_reg_write(tp, 0xb88e, 0xc23e);
+		ocp_reg_write(tp, 0xb890, 0x0000);
+		ocp_reg_write(tp, 0xb88e, 0xc240);
+		ocp_reg_write(tp, 0xb890, 0x0103);
+		ocp_reg_write(tp, 0xb88e, 0xc242);
+		ocp_reg_write(tp, 0xb890, 0x0507);
+		ocp_reg_write(tp, 0xb88e, 0xc244);
+		ocp_reg_write(tp, 0xb890, 0x090b);
+		ocp_reg_write(tp, 0xb88e, 0xc246);
+		ocp_reg_write(tp, 0xb890, 0x0c0e);
+		ocp_reg_write(tp, 0xb88e, 0xc248);
+		ocp_reg_write(tp, 0xb890, 0x1012);
+		ocp_reg_write(tp, 0xb88e, 0xc24a);
+		ocp_reg_write(tp, 0xb890, 0x1416);
+		data = ocp_reg_read(tp, 0xb896);
+		data |= BIT(0);
+		ocp_reg_write(tp, 0xb896, data);
+
+		r8153_patch_request(tp, false);
+
+		data = ocp_reg_read(tp, 0xa86a);
+		data |= BIT(0);
+		ocp_reg_write(tp, 0xa86a, data);
+		data = ocp_reg_read(tp, 0xa6f0);
+		data |= BIT(0);
+		ocp_reg_write(tp, 0xa6f0, data);
+
+		ocp_reg_write(tp, 0xbfa0, 0xd70d);
+		ocp_reg_write(tp, 0xbfa2, 0x4100);
+		ocp_reg_write(tp, 0xbfa4, 0xe868);
+		ocp_reg_write(tp, 0xbfa6, 0xdc59);
+		ocp_reg_write(tp, 0xb54c, 0x3c18);
+		data = ocp_reg_read(tp, 0xbfa4);
+		data &= ~BIT(5);
+		ocp_reg_write(tp, 0xbfa4, data);
+		data = sram_read(tp, 0x817d);
+		data |= BIT(12);
+		sram_write(tp, 0x817d, data);
+		break;
+	case RTL_VER_13:
+		// 2.5G INRX
+		data = ocp_reg_read(tp, 0xac46);
+		data &= ~0x00f0;
+		data |= 0x0090;
+		ocp_reg_write(tp, 0xac46, data);
+		data = ocp_reg_read(tp, 0xad30);
+		data &= ~0x0003;
+		data |= 0x0001;
+		ocp_reg_write(tp, 0xad30, data);
+
+		// EEE parameter
+		ocp_reg_write(tp, 0xb87c, 0x80f5);
+		ocp_reg_write(tp, 0xb87e, 0x760e);
+		ocp_reg_write(tp, 0xb87c, 0x8107);
+		ocp_reg_write(tp, 0xb87e, 0x360E);
+		ocp_reg_write(tp, 0xb87c, 0x8551);
+		data = ocp_reg_read(tp, 0xb87e);
+		data &= ~0xff00;
+		data |= 0x0800;
+		ocp_reg_write(tp, 0xb87e, data);
+
+		// ADC_PGA parameter
+		data = ocp_reg_read(tp, 0xbf00);
+		data &= ~0xe000;
+		data |= 0xa000;
+		ocp_reg_write(tp, 0xbf00, data);
+		data = ocp_reg_read(tp, 0xbf46);
+		data &= ~0x0f00;
+		data |= 0x0300;
+		ocp_reg_write(tp, 0xbf46, data);
+
+		data = sram_read(tp, 0x8044);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x8044, data);
+		data = sram_read(tp, 0x804a);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x804a, data);
+		data = sram_read(tp, 0x8050);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x8050, data);
+		data = sram_read(tp, 0x8056);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x8056, data);
+		data = sram_read(tp, 0x805c);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x805c, data);
+		data = sram_read(tp, 0x8062);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x8062, data);
+		data = sram_read(tp, 0x8068);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x8068, data);
+		data = sram_read(tp, 0x806e);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x806e, data);
+		data = sram_read(tp, 0x8074);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x8074, data);
+		data = sram_read(tp, 0x807a);
+		data &= ~0xff00;
+		data |= 0x2400;
+		sram_write(tp, 0x807a, data);
+		break;
+	default:
+		break;
+	}
+
+	if (r8153_patch_request(tp, true)) {
+		dev_err(&tp->intf->dev, "patch request fail\n");
+		return;
+	}
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4);
+	ocp_data |= EEE_SPDWN_EN;
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL4, ocp_data);
+
+	data = ocp_reg_read(tp, OCP_DOWN_SPEED);
+	data &= ~(EN_EEE_100 | EN_EEE_1000);
+	data |= EN_10M_CLKDIV;
+	ocp_reg_write(tp, OCP_DOWN_SPEED, data);
+	tp->ups_info._10m_ckdiv = true;
+	tp->ups_info.eee_plloff_100 = false;
+	tp->ups_info.eee_plloff_giga = false;
+
+	data = ocp_reg_read(tp, OCP_POWER_CFG);
+	data &= ~EEE_CLKDIV_EN;
+	ocp_reg_write(tp, OCP_POWER_CFG, data);
+	tp->ups_info.eee_ckdiv = false;
+
+	r8153_patch_request(tp, false);
+
+	rtl_green_en(tp, true);
+
+	data = ocp_reg_read(tp, 0xa428);
+	data &= ~BIT(9);
+	ocp_reg_write(tp, 0xa428, data);
+	data = ocp_reg_read(tp, 0xa5ea);
+	data &= ~BIT(0);
+	ocp_reg_write(tp, 0xa5ea, data);
+	tp->ups_info.lite_mode = 0;
+
+	if (tp->eee_en)
+		rtl_eee_enable(tp, true);
+
+	r8153_aldps_en(tp, true);
+	r8152b_enable_fc(tp);
+	r8153_u2p3en(tp, true);
+
+	set_bit(PHY_RESET, &tp->flags);
+}
+
+static void r8156_hw_phy_cfg_test(struct r8152 *tp)
 {
 	u32 ocp_data;
 	u16 data;
@@ -10848,7 +15785,7 @@ static void r8156_init(struct r8152 *tp)
 	data = r8153_phy_status(tp, 0);
 	if (data == PHY_STAT_EXT_INIT) {
 		data = ocp_reg_read(tp, 0xa468);
-		data &= ~(BIT(3) | BIT(0));
+		data &= ~(BIT(3) | BIT(1));
 		ocp_reg_write(tp, 0xa468, data);
 	}
 
@@ -10873,23 +15810,40 @@ static void r8156_init(struct r8152 *tp)
 	r8153_queue_wake(tp, false);
 	rtl_runtime_suspend_enable(tp, false);
 
-	r8153b_u1u2en(tp, true);
+	if (tp->udev->speed >= USB_SPEED_SUPER)
+		r8153b_u1u2en(tp, true);
+
 	usb_enable_lpm(tp->udev);
 
-	r8156_mac_clk_spd(tp, true);
+//	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xd850) & 0xc000;
+//	switch (ocp_data) {
+//	case 0x4000:
+//		tp->dash_mode = 1;
+//		r8156_mac_clk_spd(tp, false);
+//		break;
+//	case 0x8000:
+//		tp->dash_mode = 0;
+		r8156_mac_clk_spd(tp, true);
+//		break;
+//	default:
+//		netif_warn(tp, drv, tp->netdev, "Invalid type %x\n", ocp_data);
+//		break;
+//	}
+
 
 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
-	ocp_data &= ~BIT(14);
+	ocp_data &= ~PLA_MCU_SPDWN_EN;
 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
 
-	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xd398);
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS);
 	if (rtl8152_get_speed(tp) & LINK_STATUS)
-		ocp_data |= BIT(15);
+		ocp_data |= CUR_LINK_OK;
 	else
-		ocp_data &= ~BIT(15);
-	ocp_data &= ~BIT(8);
-	ocp_data |= BIT(0);
-	ocp_write_word(tp, MCU_TYPE_PLA, 0xd398, ocp_data);
+		ocp_data &= ~CUR_LINK_OK;
+	/* r8153_queue_wake() has cleared this bit */
+	/* ocp_data &= ~BIT(8); */
+	ocp_data |= POLL_LINK_CHG;
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS, ocp_data);
 
 //	set_bit(GREEN_ETHERNET, &tp->flags);
 
@@ -10898,9 +15852,141 @@ static void r8156_init(struct r8152 *tp)
 	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
 	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
 
-	ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, 0xcfd9);
+	/* Set Rx aggregation parameters to default value
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, 0xd4c9);
 	ocp_data |= BIT(2);
-	ocp_write_byte(tp, MCU_TYPE_USB, 0xcfd9, ocp_data);
+	ocp_write_byte(tp, MCU_TYPE_USB, 0xd4c9, ocp_data);
+	*/
+
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, 0xd4b4);
+	ocp_data |= BIT(1);
+	ocp_write_byte(tp, MCU_TYPE_USB, 0xd4b4, ocp_data);
+
+	rtl_tally_reset(tp);
+
+	tp->coalesce = 15000;	/* 15 us */
+}
+
+static void r8156b_init(struct r8152 *tp)
+{
+	u32 ocp_data;
+	u16 data;
+	int i;
+
+	if (test_bit(RTL8152_UNPLUG, &tp->flags))
+		return;
+
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, 0xd26b);
+	ocp_data &= ~BIT(0);
+	ocp_write_byte(tp, MCU_TYPE_USB, 0xd26b, ocp_data);
+
+	ocp_write_word(tp, MCU_TYPE_USB, 0xd32a, 0);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xcfee);
+	ocp_data |= BIT(5);
+	ocp_write_word(tp, MCU_TYPE_USB, 0xcfee, ocp_data);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, 0xb460);
+	ocp_data |= BIT(3);
+	ocp_write_word(tp, MCU_TYPE_USB, 0xb460, ocp_data);
+
+	r8153b_u1u2en(tp, false);
+
+	for (i = 0; i < 500; i++) {
+		if (ocp_read_word(tp, MCU_TYPE_PLA, PLA_BOOT_CTRL) &
+		    AUTOLOAD_DONE)
+			break;
+		msleep(20);
+	}
+
+	data = r8153_phy_status(tp, 0);
+	if (data == PHY_STAT_EXT_INIT) {
+		data = ocp_reg_read(tp, 0xa468);
+		data &= ~(BIT(3) | BIT(1));
+		ocp_reg_write(tp, 0xa468, data);
+
+		data = ocp_reg_read(tp, 0xa466);
+		data &= ~BIT(0);
+		ocp_reg_write(tp, 0xa466, data);
+	}
+
+	data = r8152_mdio_read(tp, MII_BMCR);
+	if (data & BMCR_PDOWN) {
+		data &= ~BMCR_PDOWN;
+		r8152_mdio_write(tp, MII_BMCR, data);
+	}
+
+	data = r8153_phy_status(tp, PHY_STAT_LAN_ON);
+
+	r8153_u2p3en(tp, false);
+
+	/* MSC timer = 0xfff * 8ms = 32760 ms */
+	ocp_write_word(tp, MCU_TYPE_USB, USB_MSC_TIMER, 0x0fff);
+
+	/* U1/U2/L1 idle timer. 500 us */
+	ocp_write_word(tp, MCU_TYPE_USB, USB_U1U2_TIMER, 500);
+
+	r8153b_power_cut_en(tp, false);
+	r8156_ups_en(tp, false);
+	r8153_queue_wake(tp, false);
+	rtl_runtime_suspend_enable(tp, false);
+
+	if (tp->udev->speed >= USB_SPEED_SUPER)
+		r8153b_u1u2en(tp, true);
+
+	usb_enable_lpm(tp->udev);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xc010);
+	ocp_data &= ~BIT(11);
+	ocp_write_word(tp, MCU_TYPE_PLA, 0xc010, ocp_data);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xe854);
+	ocp_data |= BIT(0);
+	ocp_write_word(tp, MCU_TYPE_PLA, 0xe854, ocp_data);
+
+	/* enable fc timer and set timer to 600 ms. */
+	ocp_write_word(tp, MCU_TYPE_USB, USB_FC_TIMER,
+		       CTRL_TIMER_EN | (600 / 8));
+
+	if (!(ocp_read_byte(tp, MCU_TYPE_PLA, 0xdc6b) & BIT(7))) {
+		ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xd334);
+		ocp_data |= BIT(1) | BIT(8);
+		ocp_data &= ~BIT(3);
+		ocp_write_word(tp, MCU_TYPE_PLA, 0xd334, ocp_data);
+	}
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, 0xd4e8);
+	ocp_data |= BIT(1);
+	ocp_write_word(tp, MCU_TYPE_PLA, 0xd4e8, ocp_data);
+
+	r8156b_mac_clk_spd(tp, true);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3);
+	ocp_data &= ~PLA_MCU_SPDWN_EN;
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_MAC_PWR_CTRL3, ocp_data);
+
+	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS);
+	if (rtl8152_get_speed(tp) & LINK_STATUS)
+		ocp_data |= CUR_LINK_OK;
+	else
+		ocp_data &= ~CUR_LINK_OK;
+	/* r8153_queue_wake() has cleared this bit */
+	/* ocp_data &= ~BIT(8); */
+	ocp_data |= POLL_LINK_CHG;
+	ocp_write_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS, ocp_data);
+
+//	set_bit(GREEN_ETHERNET, &tp->flags);
+
+	/* rx aggregation */
+	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
+	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
+	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
+
+	/* Set Rx aggregation parameters to default value
+	ocp_data = ocp_read_byte(tp, MCU_TYPE_USB, 0xd4c9);
+	ocp_data |= BIT(2);
+	ocp_write_byte(tp, MCU_TYPE_USB, 0xd4c9, ocp_data);
+	*/
 
 	rtl_tally_reset(tp);
 
@@ -10928,12 +16014,12 @@ static int rtl8152_pre_reset(struct usb_interface *intf)
 
 	netif_stop_queue(netdev);
 	tasklet_disable(&tp->tx_tl);
-	napi_disable(&tp->napi);
 	smp_mb__before_atomic();
 	clear_bit(WORK_ENABLE, &tp->flags);
 	smp_mb__after_atomic();
 	usb_kill_urb(tp->intr_urb);
 	cancel_delayed_work_sync(&tp->schedule);
+	napi_disable(&tp->napi);
 	if (netif_carrier_ok(netdev)) {
 		mutex_lock(&tp->control);
 		tp->rtl_ops.disable(tp);
@@ -10947,9 +16033,21 @@ static int rtl8152_post_reset(struct usb_interface *intf)
 {
 	struct r8152 *tp = usb_get_intfdata(intf);
 	struct net_device *netdev;
+	struct sockaddr sa;
 
 	if (!tp)
 		return 0;
+
+	/* reset the MAC adddress in case of policy change */
+	if (determine_ethernet_addr(tp, &sa) >= 0) {
+		rtnl_lock();
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+		dev_set_mac_address(tp->netdev, &sa);
+#else
+		dev_set_mac_address(tp->netdev, &sa, NULL);
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0) */
+		rtnl_unlock();
+	}
 
 	netdev = tp->netdev;
 	if (!netif_running(netdev))
@@ -11143,6 +16241,12 @@ static int rtl8152_system_suspend(struct r8152 *tp)
 		napi_disable(napi);
 		cancel_delayed_work_sync(&tp->schedule);
 		tp->rtl_ops.down(tp);
+
+		if (tp->version == RTL_VER_01)
+			rtl8152_set_speed(tp, AUTONEG_ENABLE, 0, 0, 3);
+		else
+			rtl_speed_down(tp);
+
 		napi_enable(napi);
 		tasklet_enable(&tp->tx_tl);
 	}
@@ -11189,10 +16293,9 @@ static int rtl8152_reset_resume(struct usb_interface *intf)
 	struct r8152 *tp = usb_get_intfdata(intf);
 
 	clear_bit(SELECTIVE_SUSPEND, &tp->flags);
-	mutex_lock(&tp->control);
 	tp->rtl_ops.init(tp);
 	queue_delayed_work(system_long_wq, &tp->hw_phy_work, 0);
-	mutex_unlock(&tp->control);
+	set_ethernet_addr(tp);
 	return rtl8152_resume(intf);
 }
 
@@ -11268,6 +16371,7 @@ static void rtl8152_get_drvinfo(struct net_device *netdev,
 	usb_make_path(tp->udev, info->bus_info, sizeof(info->bus_info));
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0)
 static
 int rtl8152_get_settings(struct net_device *netdev, struct ethtool_cmd *cmd)
 {
@@ -11318,7 +16422,7 @@ int rtl8152_get_settings(struct net_device *netdev, struct ethtool_cmd *cmd)
 
 		cmd->supported |= SUPPORTED_1000baseT_Full;
 
-		if (test_bit(SUPPORT_2500FULL, &tp->flags)) {
+		if (tp->support_2500full) {
 			u16 data = ocp_reg_read(tp, 0xa5d4);
 
 			cmd->supported |= SUPPORTED_2500baseX_Full;
@@ -11382,8 +16486,7 @@ int rtl8152_get_settings(struct net_device *netdev, struct ethtool_cmd *cmd)
 			cmd->speed = SPEED_10;
 		else if (tp->mii.supports_gmii && (speed & _1000bps))
 			cmd->speed = SPEED_1000;
-		else if (test_bit(SUPPORT_2500FULL, &tp->flags) &&
-			 (speed & _2500bps))
+		else if (tp->support_2500full && (speed & _2500bps))
 			cmd->speed = SPEED_2500;
 
 		cmd->duplex = (speed & FULL_DUP) ? DUPLEX_FULL : DUPLEX_HALF;
@@ -11400,25 +16503,40 @@ out:
 	return ret;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0)
 static int rtl8152_set_settings(struct net_device *dev, struct ethtool_cmd *cmd)
 {
 	struct r8152 *tp = netdev_priv(dev);
+	u32 advertising = 0;
 	int ret;
 
 	ret = usb_autopm_get_interface(tp->intf);
 	if (ret < 0)
 		goto out;
 
+	if (cmd->advertising & ADVERTISED_10baseT_Half)
+		advertising |= RTL_ADVERTISED_10_HALF;
+	if (cmd->advertising & ADVERTISED_10baseT_Full)
+		advertising |= RTL_ADVERTISED_10_FULL;
+	if (cmd->advertising & ADVERTISED_100baseT_Half)
+		advertising |= RTL_ADVERTISED_100_HALF;
+	if (cmd->advertising & ADVERTISED_100baseT_Full)
+		advertising |= RTL_ADVERTISED_100_FULL;
+	if (cmd->advertising & ADVERTISED_1000baseT_Half)
+		advertising |= RTL_ADVERTISED_1000_HALF;
+	if (cmd->advertising & ADVERTISED_1000baseT_Full)
+		advertising |= RTL_ADVERTISED_1000_FULL;
+	if (cmd->advertising & ADVERTISED_2500baseX_Full)
+		advertising |= RTL_ADVERTISED_2500_FULL;
+
 	mutex_lock(&tp->control);
 
 	ret = rtl8152_set_speed(tp, cmd->autoneg, cmd->speed, cmd->duplex,
-				cmd->advertising);
+				advertising);
 	if (!ret) {
 		tp->autoneg = cmd->autoneg;
 		tp->speed = cmd->speed;
 		tp->duplex = cmd->duplex;
-		tp->advertising = cmd->advertising;
+		tp->advertising = advertising;
 	}
 
 	mutex_unlock(&tp->control);
@@ -11434,31 +16552,147 @@ out:
 static int rtl8152_get_link_ksettings(struct net_device *netdev,
 				      struct ethtool_link_ksettings *cmd)
 {
-	struct ethtool_cmd ecmd;
+	struct r8152 *tp = netdev_priv(netdev);
+	u16 bmcr, bmsr, advert;
 	int ret;
 
-	memset(&ecmd, 0, sizeof(ecmd));
-	ret = rtl8152_get_settings(netdev, &ecmd);
+	ret = usb_autopm_get_interface(tp->intf);
 	if (ret < 0)
-		goto out;
+		goto out1;
 
 	/* only supports twisted-pair */
-	cmd->base.port = ecmd.port;
+	cmd->base.port = PORT_MII;
 
-	cmd->base.phy_address = ecmd.phy_address;
-	cmd->base.mdio_support = ecmd.mdio_support;
-	cmd->base.autoneg = ecmd.autoneg;
-	cmd->base.speed = ecmd.speed;
-	cmd->base.duplex = ecmd.duplex;
+	/* this isn't fully supported at higher layers */
+	cmd->base.phy_address = 32;
+	cmd->base.mdio_support = ETH_MDIO_SUPPORTS_C22;
 
-	ethtool_convert_legacy_u32_to_link_mode(cmd->link_modes.supported,
-						ecmd.supported);
-	ethtool_convert_legacy_u32_to_link_mode(cmd->link_modes.advertising,
-						ecmd.advertising);
-	ethtool_convert_legacy_u32_to_link_mode(cmd->link_modes.lp_advertising,
-						ecmd.lp_advertising);
+	linkmode_set_bit(ETHTOOL_LINK_MODE_10baseT_Half_BIT,
+			 cmd->link_modes.supported);
+	linkmode_set_bit(ETHTOOL_LINK_MODE_10baseT_Full_BIT,
+			 cmd->link_modes.supported);
+	linkmode_set_bit(ETHTOOL_LINK_MODE_100baseT_Half_BIT,
+			 cmd->link_modes.supported);
+	linkmode_set_bit(ETHTOOL_LINK_MODE_100baseT_Full_BIT,
+			 cmd->link_modes.supported);
+	linkmode_set_bit(ETHTOOL_LINK_MODE_Autoneg_BIT,
+			 cmd->link_modes.supported);
+	linkmode_set_bit(ETHTOOL_LINK_MODE_MII_BIT,
+			 cmd->link_modes.supported);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
+			 cmd->link_modes.supported, tp->mii.supports_gmii);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_2500baseT_Full_BIT,
+			 cmd->link_modes.supported, tp->support_2500full);
 
-out:
+	ret = mutex_lock_interruptible(&tp->control);
+	if (ret < 0)
+		goto out2;
+
+	bmcr = r8152_mdio_read(tp, MII_BMCR);
+	bmsr = r8152_mdio_read(tp, MII_BMSR);
+
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_Autoneg_BIT,
+			 cmd->link_modes.advertising, bmcr & BMCR_ANENABLE);
+
+	if (bmcr & BMCR_ANENABLE)
+		cmd->base.autoneg = AUTONEG_ENABLE;
+	else
+		cmd->base.autoneg = AUTONEG_DISABLE;
+
+	advert = r8152_mdio_read(tp, MII_ADVERTISE);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_10baseT_Half_BIT,
+			 cmd->link_modes.advertising,
+			 advert & ADVERTISE_10HALF);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_10baseT_Full_BIT,
+			 cmd->link_modes.advertising,
+			 advert & ADVERTISE_10FULL);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_100baseT_Half_BIT,
+			 cmd->link_modes.advertising,
+			 advert & ADVERTISE_100HALF);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_100baseT_Full_BIT,
+			 cmd->link_modes.advertising,
+			 advert & ADVERTISE_100FULL);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_Pause_BIT,
+			 cmd->link_modes.advertising,
+			 advert & ADVERTISE_PAUSE_CAP);
+	linkmode_mod_bit(ETHTOOL_LINK_MODE_Asym_Pause_BIT,
+			 cmd->link_modes.advertising,
+			 advert & ADVERTISE_PAUSE_ASYM);
+
+	if (tp->mii.supports_gmii) {
+		u16 ctrl1000 = r8152_mdio_read(tp, MII_CTRL1000);
+
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Half_BIT,
+				 cmd->link_modes.advertising,
+				 ctrl1000 & ADVERTISE_1000HALF);
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
+				 cmd->link_modes.advertising,
+				 ctrl1000 & ADVERTISE_1000FULL);
+
+		if (tp->support_2500full) {
+			u16 data = ocp_reg_read(tp, 0xa5d4);
+
+			linkmode_mod_bit(ETHTOOL_LINK_MODE_2500baseT_Full_BIT,
+					 cmd->link_modes.advertising,
+					 data & BIT(7));
+		}
+	}
+
+	if (bmsr & BMSR_ANEGCOMPLETE) {
+		advert = r8152_mdio_read(tp, MII_LPA);
+
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_Autoneg_BIT,
+				 cmd->link_modes.lp_advertising,
+				 advert & LPA_LPACK);
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_10baseT_Half_BIT,
+				 cmd->link_modes.lp_advertising,
+				 advert & ADVERTISE_10HALF);
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_10baseT_Full_BIT,
+				 cmd->link_modes.lp_advertising,
+				 advert & ADVERTISE_10FULL);
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_100baseT_Half_BIT,
+				 cmd->link_modes.lp_advertising,
+				 advert & ADVERTISE_100HALF);
+		linkmode_mod_bit(ETHTOOL_LINK_MODE_100baseT_Full_BIT,
+				 cmd->link_modes.lp_advertising,
+				 advert & ADVERTISE_100FULL);
+
+		if (tp->mii.supports_gmii) {
+			u16 stat1000 = r8152_mdio_read(tp, MII_STAT1000);
+
+			linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Half_BIT,
+					 cmd->link_modes.lp_advertising,
+					 stat1000 & LPA_1000HALF);
+			linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
+					 cmd->link_modes.lp_advertising,
+					 stat1000 & LPA_1000FULL);
+		}
+	}
+
+	if (netif_running(netdev) && netif_carrier_ok(netdev)) {
+		u16 speed = rtl8152_get_speed(tp);
+
+		if (speed & _100bps)
+			cmd->base.speed = SPEED_100;
+		else if (speed & _10bps)
+			cmd->base.speed = SPEED_10;
+		else if (tp->mii.supports_gmii && (speed & _1000bps))
+			cmd->base.speed = SPEED_1000;
+		else if (tp->support_2500full && (speed & _2500bps))
+			cmd->base.speed = SPEED_2500;
+
+		cmd->base.duplex = (speed & FULL_DUP) ? DUPLEX_FULL :
+							DUPLEX_HALF;
+	} else {
+		cmd->base.speed = SPEED_UNKNOWN;
+		cmd->base.duplex = DUPLEX_UNKNOWN;
+	}
+
+	mutex_unlock(&tp->control);
+
+out2:
+	usb_autopm_put_interface(tp->intf);
+out1:
 	return ret;
 }
 
@@ -11466,17 +16700,42 @@ static int rtl8152_set_link_ksettings(struct net_device *dev,
 				      const struct ethtool_link_ksettings *cmd)
 {
 	struct r8152 *tp = netdev_priv(dev);
-	u32 advertising;
+	u32 advertising = 0;
 	int ret;
 
 	ret = usb_autopm_get_interface(tp->intf);
 	if (ret < 0)
 		goto out;
 
-	mutex_lock(&tp->control);
+	if (test_bit(ETHTOOL_LINK_MODE_10baseT_Half_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_10_HALF;
 
-	ethtool_convert_link_mode_to_legacy_u32(&advertising,
-						cmd->link_modes.advertising);
+	if (test_bit(ETHTOOL_LINK_MODE_10baseT_Full_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_10_FULL;
+
+	if (test_bit(ETHTOOL_LINK_MODE_100baseT_Half_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_100_HALF;
+
+	if (test_bit(ETHTOOL_LINK_MODE_100baseT_Full_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_100_FULL;
+
+	if (test_bit(ETHTOOL_LINK_MODE_1000baseT_Half_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_1000_HALF;
+
+	if (test_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_1000_FULL;
+
+	if (test_bit(ETHTOOL_LINK_MODE_2500baseT_Full_BIT,
+		     cmd->link_modes.advertising))
+		advertising |= RTL_ADVERTISED_2500_FULL;
+
+	mutex_lock(&tp->control);
 
 	ret = rtl8152_set_speed(tp, cmd->base.autoneg, cmd->base.speed,
 				cmd->base.duplex, advertising);
@@ -11591,7 +16850,7 @@ static int r8152_get_eee(struct r8152 *tp, struct ethtool_eee *eee)
 	eee->eee_enabled = tp->eee_en;
 	eee->eee_active = !!(supported & adv & lp);
 	eee->supported = supported;
-	eee->advertised = adv;
+	eee->advertised = tp->eee_adv;
 	eee->lp_advertised = lp;
 
 	return 0;
@@ -11601,15 +16860,10 @@ static int r8152_set_eee(struct r8152 *tp, struct ethtool_eee *eee)
 {
 	u16 val = ethtool_adv_to_mmd_eee_adv_t(eee->advertised);
 
-	r8152_eee_en(tp, eee->eee_enabled);
 	tp->eee_en = eee->eee_enabled;
+	tp->eee_adv = val;
 
-	if (eee->eee_enabled) {
-		r8152_mmd_write(tp, MDIO_MMD_AN, MDIO_AN_EEE_ADV, val);
-		tp->eee_adv = val;
-	} else {
-		r8152_mmd_write(tp, MDIO_MMD_AN, MDIO_AN_EEE_ADV, 0);
-	}
+	rtl_eee_enable(tp, tp->eee_en);
 
 	return 0;
 }
@@ -11631,59 +16885,8 @@ static int r8153_get_eee(struct r8152 *tp, struct ethtool_eee *eee)
 	eee->eee_enabled = tp->eee_en;
 	eee->eee_active = !!(supported & adv & lp);
 	eee->supported = supported;
-	eee->advertised = adv;
+	eee->advertised = tp->eee_adv;
 	eee->lp_advertised = lp;
-
-	return 0;
-}
-
-static int r8153_set_eee(struct r8152 *tp, struct ethtool_eee *eee)
-{
-	u16 val = ethtool_adv_to_mmd_eee_adv_t(eee->advertised);
-
-	r8153_eee_en(tp, eee->eee_enabled);
-	tp->eee_en = eee->eee_enabled;
-
-	if (eee->eee_enabled) {
-		ocp_reg_write(tp, OCP_EEE_ADV, val);
-		tp->eee_adv = val;
-	} else {
-		ocp_reg_write(tp, OCP_EEE_ADV, 0);
-	}
-
-	return 0;
-}
-
-static int r8153b_set_eee(struct r8152 *tp, struct ethtool_eee *eee)
-{
-	u16 val = ethtool_adv_to_mmd_eee_adv_t(eee->advertised);
-
-	r8153_eee_en(tp, eee->eee_enabled);
-	tp->eee_en = eee->eee_enabled;
-
-	if (eee->eee_enabled) {
-		ocp_reg_write(tp, OCP_EEE_ADV, val);
-		tp->eee_adv = val;
-	} else {
-		ocp_reg_write(tp, OCP_EEE_ADV, 0);
-	}
-
-	return 0;
-}
-
-static int r8156_set_eee(struct r8152 *tp, struct ethtool_eee *eee)
-{
-	u16 val = ethtool_adv_to_mmd_eee_adv_t(eee->advertised);
-
-	r8156_eee_en(tp, eee->eee_enabled);
-	tp->eee_en = eee->eee_enabled;
-
-	if (eee->eee_enabled) {
-		ocp_reg_write(tp, OCP_EEE_ADV, val);
-		tp->eee_adv = val;
-	} else {
-		ocp_reg_write(tp, OCP_EEE_ADV, 0);
-	}
 
 	return 0;
 }
@@ -11721,7 +16924,7 @@ rtl_ethtool_set_eee(struct net_device *net, struct ethtool_eee *edata)
 	struct r8152 *tp = netdev_priv(net);
 	int ret;
 
-	if (!tp->rtl_ops.eee_get) {
+	if (!tp->rtl_ops.eee_set) {
 		ret = -EOPNOTSUPP;
 		goto out;
 	}
@@ -11780,7 +16983,7 @@ static int rtl8152_get_coalesce(struct net_device *netdev,
 		break;
 	}
 
-	coalesce->rx_coalesce_usecs = tp->coalesce;
+	coalesce->rx_coalesce_usecs = tp->coalesce / 1000;
 
 	return 0;
 }
@@ -11789,6 +16992,7 @@ static int rtl8152_set_coalesce(struct net_device *netdev,
 				struct ethtool_coalesce *coalesce)
 {
 	struct r8152 *tp = netdev_priv(netdev);
+	u32 rx_coalesce_nsecs;
 	int ret;
 
 	switch (tp->version) {
@@ -11801,7 +17005,9 @@ static int rtl8152_set_coalesce(struct net_device *netdev,
 		break;
 	}
 
-	if (coalesce->rx_coalesce_usecs > COALESCE_SLOW)
+	rx_coalesce_nsecs = coalesce->rx_coalesce_usecs * 1000;
+
+	if (rx_coalesce_nsecs > COALESCE_SLOW)
 		return -EINVAL;
 
 	ret = usb_autopm_get_interface(tp->intf);
@@ -11810,11 +17016,19 @@ static int rtl8152_set_coalesce(struct net_device *netdev,
 
 	mutex_lock(&tp->control);
 
-	if (tp->coalesce != coalesce->rx_coalesce_usecs) {
-		tp->coalesce = coalesce->rx_coalesce_usecs;
+	if (tp->coalesce != rx_coalesce_nsecs) {
+		tp->coalesce = rx_coalesce_nsecs;
 
-		if (netif_running(tp->netdev) && netif_carrier_ok(netdev))
-			r8153_set_rx_early_timeout(tp);
+		if (netif_running(netdev) && netif_carrier_ok(netdev)) {
+			netif_stop_queue(netdev);
+			napi_disable(&tp->napi);
+			tp->rtl_ops.disable(tp);
+			tp->rtl_ops.enable(tp);
+			rtl_start_rx(tp);
+			napi_enable(&tp->napi);
+			rtl8152_set_rx_mode(netdev);
+			netif_wake_queue(netdev);
+		}
 	}
 
 	mutex_unlock(&tp->control);
@@ -11830,6 +17044,91 @@ static int rtl8152_ethtool_begin(struct net_device *netdev)
 
 	if (unlikely(tp->rtk_enable_diag))
 		return -EBUSY;
+
+	return 0;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,0)
+static int rtl8152_get_tunable(struct net_device *netdev,
+			       const struct ethtool_tunable *tunable, void *d)
+{
+	struct r8152 *tp = netdev_priv(netdev);
+
+	switch (tunable->id) {
+	case ETHTOOL_RX_COPYBREAK:
+		*(u32 *)d = tp->rx_copybreak;
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+
+static int rtl8152_set_tunable(struct net_device *netdev,
+			       const struct ethtool_tunable *tunable,
+			       const void *d)
+{
+	struct r8152 *tp = netdev_priv(netdev);
+	u32 val;
+
+	switch (tunable->id) {
+	case ETHTOOL_RX_COPYBREAK:
+		val = *(u32 *)d;
+		if (val < ETH_ZLEN) {
+			netif_err(tp, rx_err, netdev,
+				  "Invalid rx copy break value\n");
+			return -EINVAL;
+		}
+
+		if (tp->rx_copybreak != val) {
+			if (netdev->flags & IFF_UP) {
+				mutex_lock(&tp->control);
+				napi_disable(&tp->napi);
+				tp->rx_copybreak = val;
+				napi_enable(&tp->napi);
+				mutex_unlock(&tp->control);
+			} else {
+				tp->rx_copybreak = val;
+			}
+		}
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	return 0;
+}
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,0) */
+
+static void rtl8152_get_ringparam(struct net_device *netdev,
+				  struct ethtool_ringparam *ring)
+{
+	struct r8152 *tp = netdev_priv(netdev);
+
+	ring->rx_max_pending = RTL8152_RX_MAX_PENDING;
+	ring->rx_pending = tp->rx_pending;
+}
+
+static int rtl8152_set_ringparam(struct net_device *netdev,
+				 struct ethtool_ringparam *ring)
+{
+	struct r8152 *tp = netdev_priv(netdev);
+
+	if (ring->rx_pending < (RTL8152_MAX_RX * 2))
+		return -EINVAL;
+
+	if (tp->rx_pending != ring->rx_pending) {
+		if (netdev->flags & IFF_UP) {
+			mutex_lock(&tp->control);
+			napi_disable(&tp->napi);
+			tp->rx_pending = ring->rx_pending;
+			napi_enable(&tp->napi);
+			mutex_unlock(&tp->control);
+		} else {
+			tp->rx_pending = ring->rx_pending;
+		}
+	}
 
 	return 0;
 }
@@ -11870,6 +17169,12 @@ static const struct ethtool_ops ops = {
 	.set_link_ksettings = rtl8152_set_link_ksettings,
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */
 	.begin = rtl8152_ethtool_begin,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,0)
+	.get_tunable = rtl8152_get_tunable,
+	.set_tunable = rtl8152_set_tunable,
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,0) */
+	.get_ringparam = rtl8152_get_ringparam,
+	.set_ringparam = rtl8152_set_ringparam,
 };
 
 static int rtltool_ioctl(struct r8152 *tp, struct ifreq *ifr)
@@ -12147,12 +17452,23 @@ static int rtl8152_change_mtu(struct net_device *dev, int new_mtu)
 	dev->mtu = new_mtu;
 
 	if (netif_running(dev)) {
-		u32 rms = new_mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
+		u32 ocp_data = new_mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
 
-		ocp_write_word(tp, MCU_TYPE_PLA, PLA_RMS, rms);
+		ocp_write_word(tp, MCU_TYPE_PLA, PLA_RMS, ocp_data);
+		r8156_fc_parameter(tp);
 
-		if (netif_carrier_ok(dev))
-			r8153_set_rx_early_size(tp);
+		if (netif_carrier_ok(dev)) {
+			netif_stop_queue(dev);
+			napi_disable(&tp->napi);
+			tasklet_disable(&tp->tx_tl);
+			tp->rtl_ops.disable(tp);
+			tp->rtl_ops.enable(tp);
+			rtl_start_rx(tp);
+			tasklet_enable(&tp->tx_tl);
+			napi_enable(&tp->napi);
+			rtl8152_set_rx_mode(dev);
+			netif_wake_queue(dev);
+		}
 	}
 
 	mutex_unlock(&tp->control);
@@ -12189,8 +17505,7 @@ static void rtl8152_unload(struct r8152 *tp)
 	if (test_bit(RTL8152_UNPLUG, &tp->flags))
 		return;
 
-	if (tp->version != RTL_VER_01)
-		r8152_power_cut_en(tp, true);
+	r8152_power_cut_en(tp, false);
 }
 
 static void rtl8153_unload(struct r8152 *tp)
@@ -12248,7 +17563,7 @@ static int rtl_ops_init(struct r8152 *tp)
 		ops->unload		= rtl8153_unload;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
 		ops->eee_get		= r8153_get_eee;
-		ops->eee_set		= r8153_set_eee;
+		ops->eee_set		= r8152_set_eee;
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0) */
 		ops->in_nway		= rtl8153_in_nway;
 		ops->hw_phy_cfg		= r8153_hw_phy_cfg;
@@ -12268,7 +17583,7 @@ static int rtl_ops_init(struct r8152 *tp)
 		ops->unload		= rtl8153b_unload;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
 		ops->eee_get		= r8153_get_eee;
-		ops->eee_set		= r8153b_set_eee;
+		ops->eee_set		= r8152_set_eee;
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0) */
 		ops->in_nway		= rtl8153_in_nway;
 		ops->hw_phy_cfg		= r8153b_hw_phy_cfg;
@@ -12290,15 +17605,16 @@ static int rtl_ops_init(struct r8152 *tp)
 //		ops->eee_set		= r8156_set_eee;
 //#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0) */
 		ops->in_nway		= rtl8153_in_nway;
-		ops->hw_phy_cfg		= r8156_hw_phy_cfg;
+		ops->hw_phy_cfg		= r8156_hw_phy_cfg_test;
 		ops->autosuspend_en	= rtl8156_runtime_enable;
 		tp->rx_buf_sz		= 48 * 1024;
-		set_bit(SUPPORT_2500FULL, &tp->flags);
+		tp->support_2500full	= 1;
 		break;
 
 	case RTL_VER_11:
 		tp->eee_en		= true;
 		tp->eee_adv		= MDIO_EEE_1000T | MDIO_EEE_100TX;
+		/* fall through */
 	case RTL_VER_10:
 		ops->init		= r8156_init;
 		ops->enable		= rtl8156_enable;
@@ -12308,18 +17624,39 @@ static int rtl_ops_init(struct r8152 *tp)
 		ops->unload		= rtl8153_unload;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
 		ops->eee_get		= r8153_get_eee;
-		ops->eee_set		= r8156_set_eee;
+		ops->eee_set		= r8152_set_eee;
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0) */
 		ops->in_nway		= rtl8153_in_nway;
-		ops->hw_phy_cfg		= r8156_hw_phy_cfg2;
+		ops->hw_phy_cfg		= r8156_hw_phy_cfg;
 		ops->autosuspend_en	= rtl8156_runtime_enable;
 		tp->rx_buf_sz		= 48 * 1024;
-		set_bit(SUPPORT_2500FULL, &tp->flags);
+		tp->support_2500full	= 1;
+		break;
+
+	case RTL_VER_12:
+	case RTL_VER_13:
+		tp->eee_en		= true;
+		tp->eee_adv		= MDIO_EEE_1000T | MDIO_EEE_100TX;
+		ops->init		= r8156b_init;
+		ops->enable		= rtl8156b_enable;
+		ops->disable		= rtl8153_disable;
+		ops->up			= rtl8156_up;
+		ops->down		= rtl8156_down;
+		ops->unload		= rtl8153_unload;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
+		ops->eee_get		= r8153_get_eee;
+		ops->eee_set		= r8152_set_eee;
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0) */
+		ops->in_nway		= rtl8153_in_nway;
+		ops->hw_phy_cfg		= r8156b_hw_phy_cfg;
+		ops->autosuspend_en	= rtl8156_runtime_enable;
+		tp->rx_buf_sz		= 48 * 1024;
+		tp->support_2500full	= 1;
 		break;
 
 	default:
 		ret = -ENODEV;
-		netif_err(tp, probe, tp->netdev, "Unknown Device\n");
+		dev_err(&tp->intf->dev, "Unknown Device\n");
 		break;
 	}
 
@@ -12383,6 +17720,12 @@ static u8 rtl_get_version(struct usb_interface *intf)
 	case 0x7030:
 		version = RTL_VER_11;
 		break;
+	case 0x7400:
+		version = RTL_VER_12;
+		break;
+	case 0x7410:
+		version = RTL_VER_13;
+		break;
 	default:
 		version = RTL_VER_UNKNOWN;
 		dev_info(&intf->dev, "Unknown version 0x%04x\n", ocp_data);
@@ -12399,8 +17742,9 @@ static u8 rtl_get_version(struct usb_interface *intf)
 static ssize_t
 ocp_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	struct usb_interface *intf = to_usb_interface(dev);
-	struct r8152 *tp = usb_get_intfdata(intf);
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	struct usb_interface *intf = tp->intf;
 	char tmp[256];
 	struct tally_counter tally;
 	int ret;
@@ -12411,14 +17755,50 @@ ocp_show(struct device *dev, struct device_attribute *attr, char *buf)
 	strcat(buf, "\n");
 
 	switch (tp->version) {
+	case RTL_VER_05:
+		strcat(buf, "RTL_VER_05\n");
+		strcat(buf, "usb_patch_code_20190904\n");
+		strcat(buf, "pla_patch_code_20190220_0\n");
+		strcat(buf, "\n\n\n\n");
+		break;
+	case RTL_VER_06:
+		strcat(buf, "RTL_VER_06\n");
+		strcat(buf, "usb_patch_20190909\n");
+		strcat(buf, "pla_patch_code_20190311_0\n");
+		strcat(buf, "\n\n\n\n");
+		break;
+	case RTL_VER_09:
+		strcat(buf, "RTL_VER_09\n");
+		strcat(buf, "usb_patch_code_20190906.cfg\n");
+		strcat(buf, "plamcu_patch_code_20190408_0\n");
+		strcat(buf, "\n\n\n\n");
+		break;
 	case RTL_VER_11:
 		strcat(buf, "RTL_VER_11\n");
-		strcat(buf, "nc_patch_181008_usb\n");
+		strcat(buf, "nc0_patch_190128_usb\n");
 		strcat(buf, "nc1_patch_181029_usb\n");
 		strcat(buf, "nc2_patch_180821_usb\n");
 		strcat(buf, "uc2_patch_181018_usb\n");
-		strcat(buf, "USB_patch_code_20180906_v2\n");
+		strcat(buf, "USB_patch_code_20190212_v3\n");
 		strcat(buf, "PLA_patch_code_20180914_v3\n");
+		break;
+	case RTL_VER_12:
+		strcat(buf, "RTL_VER_12\n");
+		strcat(buf, "nc_patch_190821_usb\n");
+		strcat(buf, "nc2_patch_190823_usb\n");
+		strcat(buf, "uc2_patch_190817_usb\n");
+		strcat(buf, "uc_patch_190731_usb\n");
+		strcat(buf, "USB_patch_code_20190816_v2\n");
+		strcat(buf, "PLA_patch_code_20190827_v2\n");
+		break;
+	case RTL_VER_13:
+		strcat(buf, "RTL_VER_13\n");
+		strcat(buf, "gphy_ramcode_v10_usb_4ByteAlign_20200116\n");
+		strcat(buf, "\n");
+		strcat(buf, "\n");
+		strcat(buf, "\n");
+		strcat(buf, "usb_patch_20200109\n");
+		strcat(buf, "pla_patch_code_svn6728_20200103\n");
 		break;
 	default:
 		strcat(buf, "\n\n\n\n\n\n\n");
@@ -12566,16 +17946,12 @@ out1:
 static ssize_t ocp_store(struct device *dev, struct device_attribute *attr,
 			 const char *buf, size_t count)
 {
-	struct usb_interface *intf;
-	struct net_device *netdev;
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	struct usb_interface *intf = tp->intf;
 	u32 v1, v2, v3, v4;
-	struct r8152 *tp;
 	u16 type;
-	int num;
-
-	intf = to_usb_interface(dev);
-	tp = usb_get_intfdata(intf);
-	netdev = tp->netdev;
+	int num, ret;
 
 	if (!strncmp(buf, "pla ", 4))
 		type = MCU_TYPE_PLA;
@@ -12597,12 +17973,12 @@ static ssize_t ocp_store(struct device *dev, struct device_attribute *attr,
 			return -EINVAL;
 	}
 
-	count = usb_autopm_get_interface(intf);
-	if (count < 0)
-		return count;
+	ret = usb_autopm_get_interface(intf);
+	if (ret < 0)
+		return ret;
 
-	count = mutex_lock_interruptible(&tp->control);
-	if (count < 0)
+	ret = mutex_lock_interruptible(&tp->control);
+	if (ret < 0)
 		goto put;
 
 	switch(num) {
@@ -12624,7 +18000,7 @@ static ssize_t ocp_store(struct device *dev, struct device_attribute *attr,
 				   ocp_read_dword(tp, type, v2));
 			break;
 		default:
-			count = -EINVAL;
+			ret = -EINVAL;
 			break;
 		}
 		break;
@@ -12646,14 +18022,14 @@ static ssize_t ocp_store(struct device *dev, struct device_attribute *attr,
 			ocp_write_dword(tp, type, v2, v3);
 			break;
 		default:
-			count = -EINVAL;
+			ret = -EINVAL;
 			break;
 		}
 		break;
 	case 4:
 	case 1:
 	default:
-		count = -EINVAL;
+		ret = -EINVAL;
 		break;
 	}
 
@@ -12662,7 +18038,10 @@ static ssize_t ocp_store(struct device *dev, struct device_attribute *attr,
 put:
 	usb_autopm_put_interface(intf);
 
-	return count;
+	if (ret < 0)
+		return ret;
+	else
+		return count;
 }
 
 static DEVICE_ATTR_RW(ocp);
@@ -12680,20 +18059,26 @@ static ssize_t pla_read(struct file *fp, struct kobject *kobj,
 			size_t size)
 {
 	struct device *dev = kobj_to_dev(kobj);
-	struct usb_interface *intf = to_usb_interface(dev);
-	struct r8152 *tp = usb_get_intfdata(intf);
-	struct net_device *netdev = tp->netdev;
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	int ret;
 
 	if (size <= ATTR_PLA_SIZE)
 		size = min(size, ATTR_PLA_SIZE - (size_t)offset);
 	else
 		return -EINVAL;
 
-	/* rtnl_lock(); */
-	if (mutex_lock_interruptible(&tp->control))
-		return -EINTR;
+	ret = usb_autopm_get_interface(intf);
+	if (ret < 0)
+		return ret;
 
-	if (pla_ocp_read(tp, offset + 0xc000, (u16)size, buf) < 0)
+	/* rtnl_lock(); */
+	ret = mutex_lock_interruptible(&tp->control)
+	if (ret < 0)
+		goto put;
+
+	ret = pla_ocp_read(tp, offset + 0xc000, (u16)size, buf);
+	if (ret < 0)
 		netif_err(tp, drv, netdev,
 			  "Read PLA offset 0x%Lx, len = %zd fail\n",
 			  offset + 0xc000, size);
@@ -12701,7 +18086,13 @@ static ssize_t pla_read(struct file *fp, struct kobject *kobj,
 	mutex_unlock(&tp->control);
 	/* rtnl_unlock(); */
 
-	return size;
+put:
+	usb_autopm_put_interface(intf);
+
+	if (ret < 0)
+		return ret;
+	else
+		return size;
 }
 
 static BIN_ATTR_RO(pla, ATTR_PLA_SIZE);
@@ -12711,13 +18102,298 @@ static struct bin_attribute *rtk_bin_attrs[] = {
 	NULL
 };
 
-static struct attribute_group rtk_attr_grp = {
+static struct attribute_group rtk_dbg_grp = {
 	.name = "nic_swsd",
 	.attrs = rtk_attrs,
 	.bin_attrs = rtk_bin_attrs,
 };
 
-#endif
+#endif /* RTL8152_DEBUG */
+
+static ssize_t rx_copybreak_show(struct device *dev,
+				 struct device_attribute *attr, char *buf)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+
+	sprintf(buf, "%u\n", tp->rx_copybreak);
+
+	return strlen(buf);
+}
+
+static ssize_t rx_copybreak_store(struct device *dev,
+				  struct device_attribute *attr,
+				  const char *buf, size_t count)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	u32 rx_copybreak;
+
+	if (sscanf(buf, "%u\n", &rx_copybreak) != 1)
+		return -EINVAL;
+
+	if (rx_copybreak < ETH_ZLEN)
+		return -EINVAL;
+
+	if (test_bit(RTL8152_UNPLUG, &tp->flags))
+		return -ENODEV;
+
+	if (tp->rx_copybreak != rx_copybreak) {
+		if (tp->netdev->flags & IFF_UP) {
+			int ret;
+
+			ret = mutex_lock_interruptible(&tp->control);
+			if (ret < 0)
+				return ret;
+
+			napi_disable(&tp->napi);
+			tp->rx_copybreak = rx_copybreak;
+			napi_enable(&tp->napi);
+
+			mutex_unlock(&tp->control);
+		} else {
+			tp->rx_copybreak = rx_copybreak;
+		}
+	}
+
+	return count;
+}
+
+static DEVICE_ATTR_RW(rx_copybreak);
+
+static ssize_t fc_pause_show(struct device *dev,
+			     struct device_attribute *attr, char *buf)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+
+	if (!tp->fc_pause) {
+		u32 fc_pause;
+
+		fc_pause = netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
+		fc_pause = 0x800 + ALIGN(fc_pause, 1024);
+		sprintf(buf, "(Auto)%u\n", fc_pause);
+	} else {
+		sprintf(buf, "%u\n", tp->fc_pause);
+	}
+
+	return strlen(buf);
+}
+
+static ssize_t fc_pause_store(struct device *dev,
+			      struct device_attribute *attr,
+			      const char *buf, size_t count)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	struct usb_interface *intf = tp->intf;
+	u32 fc_pause, fc_restart;
+	int ret = 0;
+
+	if (test_bit(RTL8152_UNPLUG, &tp->flags))
+		return -ENODEV;
+
+	if (sscanf(buf, "%u\n", &fc_pause) != 1)
+		return -EINVAL;
+
+	if (tp->fc_restart) {
+		fc_restart = tp->fc_restart;
+	} else {
+		fc_restart = netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
+		fc_restart = 0x1800 + ALIGN(fc_restart, 1024);
+	}
+
+	if (fc_pause && (fc_pause >= fc_restart)) {
+		netif_err(tp, drv, netdev, "fc_pause must be less than %u\n",
+			  fc_restart);
+		return -EINVAL;
+	}
+
+	if (tp->fc_pause != fc_pause) {
+		ret = usb_autopm_get_interface(intf);
+		if (ret < 0)
+			return ret;
+
+		ret = mutex_lock_interruptible(&tp->control);
+		if (ret < 0)
+			goto put;
+
+		tp->fc_pause = fc_pause;
+
+		if (netdev->flags & IFF_UP) {
+			r8156_fc_parameter(tp);
+
+			if (netif_carrier_ok(netdev)) {
+				netif_stop_queue(netdev);
+				napi_disable(&tp->napi);
+				tasklet_disable(&tp->tx_tl);
+				tp->rtl_ops.disable(tp);
+				tp->rtl_ops.enable(tp);
+				rtl_start_rx(tp);
+				tasklet_enable(&tp->tx_tl);
+				napi_enable(&tp->napi);
+				rtl8152_set_rx_mode(netdev);
+				netif_wake_queue(netdev);
+			}
+		}
+
+		mutex_unlock(&tp->control);
+
+put:
+		usb_autopm_put_interface(intf);
+	}
+
+	if (ret < 0)
+		return ret;
+	else
+		return count;
+}
+
+static DEVICE_ATTR_RW(fc_pause);
+
+static ssize_t fc_restart_show(struct device *dev,
+			       struct device_attribute *attr, char *buf)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+
+	if (!tp->fc_restart) {
+		u32 fc_restart;
+
+		fc_restart = netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
+		fc_restart = 0x1800 + ALIGN(fc_restart, 1024);
+		sprintf(buf, "(Auto)%u\n", fc_restart);
+	} else {
+		sprintf(buf, "%u\n", tp->fc_restart);
+	}
+
+	return strlen(buf);
+}
+
+static ssize_t fc_restart_store(struct device *dev,
+				struct device_attribute *attr,
+				const char *buf, size_t count)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	struct usb_interface *intf = tp->intf;
+	u32 fc_pause, fc_restart;
+	int ret = 0;
+
+	if (test_bit(RTL8152_UNPLUG, &tp->flags))
+		return -ENODEV;
+
+	if (sscanf(buf, "%u\n", &fc_restart) != 1)
+		return -EINVAL;
+
+	if (tp->fc_pause) {
+		fc_pause = tp->fc_pause;
+	} else {
+		fc_pause = netdev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
+		fc_pause = 0x800 + ALIGN(fc_pause, 1024);
+	}
+
+	if (fc_restart && (fc_restart <= tp->fc_pause)) {
+		netif_err(tp, drv, netdev, "fc_restart must be more than %u\n",
+			  tp->fc_pause);
+		return -EINVAL;
+	}
+
+	if (tp->fc_restart != fc_restart) {
+		ret = usb_autopm_get_interface(intf);
+		if (ret < 0)
+			return ret;
+
+		ret = mutex_lock_interruptible(&tp->control);
+		if (ret < 0)
+			goto put;
+
+		tp->fc_restart = fc_restart;
+
+		if (netdev->flags & IFF_UP) {
+			r8156_fc_parameter(tp);
+
+			if (netif_carrier_ok(netdev)) {
+				netif_stop_queue(netdev);
+				napi_disable(&tp->napi);
+				tasklet_disable(&tp->tx_tl);
+				tp->rtl_ops.disable(tp);
+				tp->rtl_ops.enable(tp);
+				rtl_start_rx(tp);
+				tasklet_enable(&tp->tx_tl);
+				napi_enable(&tp->napi);
+				rtl8152_set_rx_mode(netdev);
+				netif_wake_queue(netdev);
+			}
+		}
+
+		mutex_unlock(&tp->control);
+
+put:
+		usb_autopm_put_interface(intf);
+	}
+
+	if (ret < 0)
+		return ret;
+	else
+		return count;
+}
+
+static DEVICE_ATTR_RW(fc_restart);
+
+static ssize_t
+sg_en_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+
+	if (tp->sg_use)
+		strcat(buf, "enable\n");
+	else
+		strcat(buf, "disable\n");
+
+	return strlen(buf);
+}
+
+static ssize_t sg_en_store(struct device *dev, struct device_attribute *attr,
+			   const char *buf, size_t count)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct r8152 *tp = netdev_priv(netdev);
+	u32 tso_size;
+
+	if (!strncmp(buf, "enable", 6) &&
+	    usb_device_no_sg_constraint(tp->udev)) {
+		tp->sg_use = true;
+		tso_size = GSO_MAX_SIZE;
+	} else if (!strncmp(buf, "disable", 7)) {
+		tp->sg_use = false;
+		tso_size = RTL_LIMITED_TSO_SIZE;
+	} else {
+		return -EINVAL;
+	}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26)
+	netif_set_gso_max_size(netdev, tso_size);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26) */
+
+	return count;
+}
+
+static DEVICE_ATTR_RW(sg_en);
+
+static struct attribute *rtk_adv_attrs[] = {
+	&dev_attr_rx_copybreak.attr,
+	&dev_attr_sg_en.attr,
+	&dev_attr_fc_pause.attr,
+	&dev_attr_fc_restart.attr,
+	NULL
+};
+
+static struct attribute_group rtk_adv_grp = {
+	.name = "rtl_adv",
+	.attrs = rtk_adv_attrs,
+};
 
 static int rtl8152_probe(struct usb_interface *intf,
 			 const struct usb_device_id *id)
@@ -12739,6 +18415,9 @@ static int rtl8152_probe(struct usb_interface *intf,
 #endif
 		return -ENODEV;
 	}
+
+	if (intf->cur_altsetting->desc.bNumEndpoints < 3)
+		return -ENODEV;
 
 	usb_reset_device(udev);
 	netdev = alloc_etherdev(sizeof(struct r8152));
@@ -12776,6 +18455,11 @@ static int rtl8152_probe(struct usb_interface *intf,
 	INIT_DELAYED_WORK(&tp->hw_phy_work, rtl_hw_phy_work_func_t);
 	tasklet_init(&tp->tx_tl, bottom_half, (unsigned long)tp);
 	tasklet_disable(&tp->tx_tl);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,2,3)
+	if (usb_device_no_sg_constraint(udev))
+		tp->sg_use = true;
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5,2,3) */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29)
 	netdev->open = rtl8152_open;
@@ -12819,9 +18503,13 @@ static int rtl8152_probe(struct usb_interface *intf,
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39) */
 	}
 
+	if (le16_to_cpu(udev->descriptor.idVendor) == VENDOR_ID_LENOVO)
+		tp->lenovo_macpassthru = 1;
+
 	netdev->ethtool_ops = &ops;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26)
-	netif_set_gso_max_size(netdev, RTL_LIMITED_TSO_SIZE);
+	if (!tp->sg_use)
+		netif_set_gso_max_size(netdev, RTL_LIMITED_TSO_SIZE);
 #else
 	netdev->features &= ~(NETIF_F_TSO | NETIF_F_TSO6);
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26) */
@@ -12852,20 +18540,22 @@ static int rtl8152_probe(struct usb_interface *intf,
 
 	tp->autoneg = AUTONEG_ENABLE;
 	tp->speed = SPEED_100;
-	tp->advertising = ADVERTISED_10baseT_Half | ADVERTISED_10baseT_Full |
-			  ADVERTISED_100baseT_Half |
-			  ADVERTISED_100baseT_Full;
+	tp->advertising = RTL_ADVERTISED_10_HALF | RTL_ADVERTISED_10_FULL |
+			  RTL_ADVERTISED_100_HALF | RTL_ADVERTISED_100_FULL;
 	if (tp->mii.supports_gmii) {
-		if (test_bit(SUPPORT_2500FULL, &tp->flags) &&
+		if (tp->support_2500full &&
 		    tp->udev->speed >= USB_SPEED_SUPER) {
 			tp->speed = SPEED_2500;
-			tp->advertising |= ADVERTISED_2500baseX_Full;
+			tp->advertising |= RTL_ADVERTISED_2500_FULL;
 		} else {
 			tp->speed = SPEED_1000;
 		}
-		tp->advertising |= ADVERTISED_1000baseT_Full;
+		tp->advertising |= RTL_ADVERTISED_1000_FULL;
 	}
 	tp->duplex = DUPLEX_FULL;
+
+	tp->rx_copybreak = RTL8152_RXFG_HEADSZ;
+	tp->rx_pending = 10 * RTL8152_MAX_RX;
 
 	intf->needs_remote_wakeup = 1;
 
@@ -12879,11 +18569,15 @@ static int rtl8152_probe(struct usb_interface *intf,
 	set_ethernet_addr(tp);
 
 	usb_set_intfdata(intf, tp);
-	netif_napi_add(netdev, &tp->napi, r8152_poll, RTL8152_NAPI_WEIGHT);
+
+	if (tp->support_2500full)
+		netif_napi_add(netdev, &tp->napi, r8152_poll, 256);
+	else
+		netif_napi_add(netdev, &tp->napi, r8152_poll, 64);
 
 	ret = register_netdev(netdev);
 	if (ret != 0) {
-		netif_err(tp, probe, netdev, "couldn't register the device\n");
+		dev_err(&intf->dev, "couldn't register the device\n");
 		goto out1;
 	}
 
@@ -12897,13 +18591,28 @@ static int rtl8152_probe(struct usb_interface *intf,
 	netif_info(tp, probe, netdev, "%s\n", DRIVER_VERSION);
 	netif_info(tp, probe, netdev, "%s\n", PATENTS);
 
+	ret = sysfs_create_group(&netdev->dev.kobj, &rtk_adv_grp);
+	if (ret < 0) {
+		netif_err(tp, probe, netdev, "creat rtk_adv_grp fail\n");
+		goto out2;
+	}
+
 #ifdef RTL8152_DEBUG
-	if (sysfs_create_group(&intf->dev.kobj, &rtk_attr_grp) < 0)
-		netif_err(tp, probe, netdev, "creat rtk_attr_grp fail\n");
+	ret = sysfs_create_group(&netdev->dev.kobj, &rtk_dbg_grp);
+	if (ret < 0) {
+		netif_err(tp, probe, netdev, "creat rtk_dbg_grp fail\n");
+		goto out3;
+	}
 #endif
 
 	return 0;
 
+#ifdef RTL8152_DEBUG
+out3:
+	sysfs_remove_group(&intf->dev.kobj, &rtk_adv_grp);
+#endif
+out2:
+	unregister_netdev(netdev);
 out1:
 	netif_napi_del(&tp->napi);
 	tasklet_kill(&tp->tx_tl);
@@ -12918,8 +18627,9 @@ static void rtl8152_disconnect(struct usb_interface *intf)
 	struct r8152 *tp = usb_get_intfdata(intf);
 
 #ifdef RTL8152_DEBUG
-	sysfs_remove_group(&intf->dev.kobj, &rtk_attr_grp);
+	sysfs_remove_group(&intf->dev.kobj, &rtk_dbg_grp);
 #endif
+	sysfs_remove_group(&intf->dev.kobj, &rtk_adv_grp);
 
 	usb_set_intfdata(intf, NULL);
 	if (tp) {
@@ -12953,6 +18663,7 @@ static const struct usb_device_id rtl8152_table[] = {
 	{REALTEK_USB_DEVICE(VENDOR_ID_REALTEK, 0x8050)},
 	{REALTEK_USB_DEVICE(VENDOR_ID_REALTEK, 0x8152)},
 	{REALTEK_USB_DEVICE(VENDOR_ID_REALTEK, 0x8153)},
+	{REALTEK_USB_DEVICE(VENDOR_ID_REALTEK, 0x8155)},
 	{REALTEK_USB_DEVICE(VENDOR_ID_REALTEK, 0x8156)},
 
 	/* Microsoft */
@@ -12985,8 +18696,9 @@ static const struct usb_device_id rtl8152_table[] = {
 	/* Nvidia */
 	{REALTEK_USB_DEVICE(VENDOR_ID_NVIDIA,  0x09ff)},
 
-	/* TRENDnet */
-	{REALTEK_USB_DEVICE(VENDOR_ID_TRENDNET, 0xe02b)},
+	/* LINKSYS */
+	{REALTEK_USB_DEVICE(VENDOR_ID_LINKSYS, 0x0041)},
+
 	{}
 };
 


### PR DESCRIPTION
I newly purchased a network card based on RTL8156B, named "DIEWU TXA086". When using the 2.12.0-3 version driver, I get "Unknown version 0x7410". After updating the Realtek official driver to 2.13.0, the device was successfully recognized.