### PR TITLE
Sleep 15s to fix rebooting problem for some models.

### DIFF
--- a/scripts/start-stop-status
+++ b/scripts/start-stop-status
@@ -49,7 +49,7 @@ set_interfaces()
 case $1 in
 	start)
 		/sbin/insmod $SYNOPKG_PKGDEST/r8152/r8152.ko
-		sleep 10
+		sleep 15
 		set_interfaces up
 		exit 0
 	;;


### PR DESCRIPTION
As some users' report(#105), and my friend's, and mine, interface is not shown after reboot.
Increasing sleep time to 15 actually helps.