### PR TITLE
fix transmit queue timeout

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -2450,6 +2450,8 @@ static void write_bulk_callback(struct urb *urb)
 	if (test_bit(RTL8152_UNPLUG, &tp->flags))
 		return;
 
+	netif_trans_update(netdev);
+
 	if (!skb_queue_empty(&tp->tx_queue))
 		tasklet_schedule(&tp->tx_tl);
 }
@@ -2509,6 +2511,8 @@ static void write_bulk_sg_callback(struct urb *urb)
 
 	if (test_bit(RTL8152_UNPLUG, &tp->flags))
 		return;
+
+	netif_trans_update(netdev);
 
 	if (!skb_queue_empty(&tp->tx_queue))
 		tasklet_schedule(&tp->tx_tl);


### PR DESCRIPTION
The TX queue length reached the threshold and stopped working, ultimately causing the network card to reset.

This patch will proactively refresh the netdev watchdog transmission start time (feed the dog) after each USB submission completes.

Reproducibility conditions: Maintain TX traffic at approximately 400 Mbits/sec for 60 seconds.